### PR TITLE
Closes #34: Django-nose, coverage and coveralls setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,6 @@ before_script:
 
 script:
   - python manage.py test
+
+after_script:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sleuth :mag_right: 
 [![ZenHub](https://raw.githubusercontent.com/ZenHubIO/support/master/zenhub-badge.png)](https://zenhub.com)
 [![Build Status](https://travis-ci.org/ubclaunchpad/sleuth.svg?branch=master)](https://travis-ci.org/ubclaunchpad/sleuth)
+[![Coverage Status](https://coveralls.io/repos/github/ubclaunchpad/sleuth/badge.svg)](https://coveralls.io/github/ubclaunchpad/sleuth)
 
 UBC's own search engine :rocket:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   frontend:
     build: 
       context: ../sleuth-frontend
-    command: yarn start --host 0.0.0.0 --port 8080
+    command: sh -c "yarn && yarn start --host 0.0.0.0 --port 8080"
     volumes:
       - ../sleuth-frontend:/home/sleuth-frontend
     ports: 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ docutils
 django-haystack
 pysolr
 django-cors-headers
+django-nose
+coverage
+coveralls

--- a/sleuth/settings.py
+++ b/sleuth/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admindocs',
+    'django_nose',
     'haystack',
     'corsheaders',
 ]
@@ -136,6 +137,16 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Test runners
+# https://django-testing-docs.readthedocs.io/en/latest/coverage.html#configure-django-nose
+TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+NOSE_ARGS = [
+    '--with-coverage',
+    '--cover-package=sleuth_backend,sleuth_crawler',
+]
+
+NOSE_IGNORE_CONFIG_FILES = True,
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.11/topics/i18n/


### PR DESCRIPTION
## Related Issue
#34 

## Description
* Use django-nose, coverage and coveralls to generate coverage repots while running tests in Travis
* Coverage covers `sleuth_backend` and `sleuth_scraper`
* Add one last missing `__init__.py` in `scraper`
* Update `docker-compose` script to install JS dependencies

## Todos
* ~~Make sure it works~~ It works! Some decisions to make:

- [ ] Do we want coverage to include the tests themselves? (it does at the moment) [StackOverflow insight](https://stackoverflow.com/questions/1628996/is-it-possible-exclude-test-directories-from-coverage-py-reports) on the matter:
> It's a good idea to see the coverage of your tests as it can point to problems. If your test code isn't being run then there wasn't much point in writing it!

Also doesn't seem to be a straight-forward way to omit things, ie `__init__.py`, with django-nose
- [ ] Coveralls comments or slack bots?