### PR TITLE
Closes #48: Unit tests for crawler and new crawler modules, improved scraping

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+omit =
+    */tests/*

--- a/sleuth_backend/solr/models.py
+++ b/sleuth_backend/solr/models.py
@@ -48,7 +48,6 @@ class GenericPage(SolrDocument):
         "siteName": "",
         "updatedAt": "",
         "pageName": "",
-        "pageTitle": "",
         "description": "",
         "content": "",
         "children": []
@@ -65,7 +64,6 @@ class GenericPage(SolrDocument):
             "data": {
                 "updatedAt": self.doc['updatedAt'],
                 "pageName": self.doc['pageName'],
-                "pageTitle": self.doc['pageTitle'],
                 "description": self.doc['description']
             }
         }

--- a/sleuth_backend/tests/test_models.py
+++ b/sleuth_backend/tests/test_models.py
@@ -11,7 +11,6 @@ class TestGenericPage(TestCase):
             "siteName": "testname",
             "updatedAt": "9827359348752937402",
             "pageName": "testpage",
-            "pageTitle": "testtitle",
             "content": "testcontent",
             "description": "testblurb",
             "children": []
@@ -34,7 +33,6 @@ class TestGenericPage(TestCase):
                 "data": {
                     "updatedAt": args["updatedAt"],
                     "pageName": args["pageName"],
-                    "pageTitle": args["pageTitle"],
                     "description": args["description"]
                 }
             },

--- a/sleuth_crawler/scraper/scraper/items.py
+++ b/sleuth_crawler/scraper/scraper/items.py
@@ -13,6 +13,7 @@ class ScrapyGenericPage(scrapy.Item):
     """
     url = scrapy.Field()
     title = scrapy.Field()
+    site_title = scrapy.Field()
     description = scrapy.Field()
     raw_content = scrapy.Field()
     children = scrapy.Field()

--- a/sleuth_crawler/scraper/scraper/pipelines.py
+++ b/sleuth_crawler/scraper/scraper/pipelines.py
@@ -43,8 +43,8 @@ class SolrPipeline(object):
         solr_doc = GenericPage(
             id=item["url"],
             type="genericPage",
-            siteName=item["title"],
-            pageName=item["site_title"],
+            siteName=item["site_title"],
+            pageName=item["title"],
             updatedAt=self.__make_date(),
             content=self.__parse_content(item["raw_content"]),
             description=item["description"],

--- a/sleuth_crawler/scraper/scraper/pipelines.py
+++ b/sleuth_crawler/scraper/scraper/pipelines.py
@@ -43,7 +43,8 @@ class SolrPipeline(object):
         solr_doc = GenericPage(
             id=item["url"],
             type="genericPage",
-            sitename=item["title"],
+            siteName=item["title"],
+            pageName=item["site_title"],
             updatedAt=self.__make_date(),
             content=self.__parse_content(item["raw_content"]),
             description=item["description"],

--- a/sleuth_crawler/scraper/scraper/settings.py
+++ b/sleuth_crawler/scraper/scraper/settings.py
@@ -21,9 +21,10 @@ SPIDER_MODULES = ['scraper.spiders']
 NEWSPIDER_MODULE = 'scraper.spiders'
 
 # List approved starting URLs to be crawled by BroadCrawler
+# Place specific domains before www.ubc.ca
 PARENT_URLS = [
-    'http://www.ubc.ca',
     'https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=0',
+    'http://www.ubc.ca',
 ]
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent

--- a/sleuth_crawler/scraper/scraper/spiders/broad_crawler.py
+++ b/sleuth_crawler/scraper/scraper/spiders/broad_crawler.py
@@ -46,7 +46,7 @@ class BroadCrawler(CrawlSpider):
         
     def parse_generic_item(self, response):
         """
-        Points to generic_page_parser
+        Points to generic_page_parser (the default parser for this crawler)
         """
         children = []
         for link in self.GENERIC_LINK_EXTRACTOR.extract_links(response):

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/course_parser.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/course_parser.py
@@ -1,5 +1,5 @@
 import scrapy
-import sleuth_crawler.scraper.scraper.spiders.parsers.utils as utils
+from sleuth_crawler.scraper.scraper.spiders.parsers import utils
 from sleuth_crawler.scraper.scraper.items import ScrapyCourseItem
 
 BASE_URL = "https://courses.students.ubc.ca"

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
@@ -10,8 +10,8 @@ def parse_generic_item(response, children):
     title = utils.extract_element(response.xpath("//title/text()"), 0)
     titles = title.split('|')
     if len(titles) == 2:
-        title = utils.strip_content(titles[0])
-        site_title = utils.strip_content(titles[1])
+        title = titles[0].strip()
+        site_title = titles[1].strip()
     desc = utils.extract_element(response.xpath("//meta[@name='description']/@content"), 0)
     raw_content = utils.strip_content(response.body)
 

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
@@ -6,13 +6,19 @@ def parse_generic_item(response, children):
     """
     Scrape generic page
     """
+    site_title = ""
     title = utils.extract_element(response.xpath("//title/text()"), 0)
+    titles = title.split('|')
+    if len(titles) == 2:
+        title = utils.strip_content(titles[0])
+        site_title = utils.strip_content(titles[1])
     desc = utils.extract_element(response.xpath("//meta[@name='description']/@content"), 0)
     raw_content = utils.strip_content(response.body)
 
     return ScrapyGenericPage(
         url=response.url,
         title=title,
+        site_title=site_title,
         description=desc,
         raw_content=raw_content,
         children=children

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
@@ -1,5 +1,5 @@
 import scrapy
-import sleuth_crawler.scraper.scraper.spiders.parsers.utils as utils
+from sleuth_crawler.scraper.scraper.spiders.parsers import utils
 from sleuth_crawler.scraper.scraper.items import ScrapyGenericPage
 
 def parse_generic_item(response, children):

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/utils.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/utils.py
@@ -19,7 +19,7 @@ def strip_content(data):
         return lines
     except Exception:
         # if page is not a webpage, catch errors on attempted parse
-        return None
+        return [""]
 
 def extract_element(item_list, index):
     """

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/utils.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/utils.py
@@ -15,17 +15,17 @@ def strip_content(data):
         for line in data.splitlines():
             line = line.strip()
             if line:
-                lines.append(line.strip())
+                lines.append(line)
         return lines
     except Exception:
         # if page is not a webpage, catch errors on attempted parse
-        return [""]
+        return []
 
 def extract_element(item_list, index):
     """
     Safely extract indexed xpath element
     """
-    try:
+    if index < len(item_list):
         return item_list[index].extract()
-    except IndexError:
+    else:
         return ""

--- a/sleuth_crawler/tests/mocks.py
+++ b/sleuth_crawler/tests/mocks.py
@@ -7,10 +7,10 @@ def mock_response(file_name=None, url=None):
 
     if not url:
         url = 'http://www.ubc.ca'
+    request = Request(url=url)
 
     if file_name:
         file_path = "sleuth_crawler/tests" + file_name
-        request = Request(url=url)
         file_content = open(file_path, 'r').read()
     else:
         file_content = ""

--- a/sleuth_crawler/tests/mocks.py
+++ b/sleuth_crawler/tests/mocks.py
@@ -1,23 +1,23 @@
 from scrapy.http import Request, TextResponse
 
-def mock_response(file_name, url=None):
+def mock_response(file_name=None, url=None):
     """
-    Create a Scrapy fake HTTP response from a given HTML file
+    Create a fake Scrapy HTTP response
     """
 
     if not url:
         url = 'http://www.ubc.ca'
 
-    file_path = "sleuth_crawler/tests" + file_name
+    if file_name:
+        file_path = "sleuth_crawler/tests" + file_name
+        request = Request(url=url)
+        file_content = open(file_path, 'r').read()
+    else:
+        file_content = ""
 
-    request = Request(url=url)
-    file_content = open(file_path, 'r').read()
-
-    response = TextResponse(
+    return TextResponse(
         url=url,
         request=request,
         body=file_content,
         encoding='utf-8'
     )
-
-    return response

--- a/sleuth_crawler/tests/test_course_parser.py
+++ b/sleuth_crawler/tests/test_course_parser.py
@@ -1,0 +1,73 @@
+from django.test import TestCase
+from sleuth_crawler.tests.mocks import mock_response
+from sleuth_crawler.scraper.scraper.items import ScrapyCourseItem
+from sleuth_crawler.scraper.scraper.spiders.parsers import course_parser as parser
+import re
+
+class TestCourseParser(TestCase):
+    """
+    Test GenericCourseParser
+    parsers.course_oarser
+    """
+
+    def test_parse_subjects(self):
+        """
+        Test subjects parsing
+        """
+        response = mock_response('/test_data/subjects.txt', 'https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=0')
+        output = list(parser.parse_subjects(response))
+        expected_subjects = [
+            {
+                "url": "https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=1&dept=AANB",
+                "name": "AANB Applied Animal Biology",
+                "faculty": "Faculty of Land and Food Systems"
+            },
+            {
+                "url": "https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=1&dept=ACAM",
+                "name": "ACAM Asian Canadian and Asian Migration Studies",
+                "faculty": "Faculty of Arts"
+            }
+        ]
+        self.assertEquals(output[0].callback.__name__, parser.parse_course.__name__)
+        self.assertEquals(output[0].meta['data'],expected_subjects[0])
+        self.assertEquals(output[1].meta['data'],expected_subjects[1])
+
+    def test_parse_course(self):
+        """
+        Test courses parsing
+        """
+        response = mock_response(
+            '/test_data/courses.txt', 
+            'https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=1&dept=ASTR'
+        )
+        response.meta['data'] = {"url":"some_url"}
+        output = list(parser.parse_course(response))
+        expected_courses = [
+            ScrapyCourseItem(
+                subject={"url":"some_url"},
+                url="https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=3&dept=GRSJ&course=101",
+                name="GRSJ 101 Introduction to Social Justice"
+            ),
+            ScrapyCourseItem(
+                subject={"url":"some_url"},
+                url="https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=3&dept=GRSJ&course=102",
+                name="GRSJ 102 Global Issues in Social Justice"
+            )
+        ]
+        self.assertEquals(output[0].callback.__name__, parser.parse_course_details.__name__)
+        self.assertEquals(output[0].meta['data'],expected_courses[0])
+        self.assertEquals(output[1].meta['data'],expected_courses[1])
+
+    def test_parse_course_details(self):
+        """
+        Test course details parsing
+        """
+        response = mock_response('/test_data/course_details.txt', 'https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=3&dept=ASTR&course=200')
+        response.meta['data'] = ScrapyCourseItem(subject="",url="",name="")
+        output = parser.parse_course_details(response)
+        expected_course = ScrapyCourseItem(
+            subject="", url="", name="",
+            description="An overview of intersectional feminist debates and theoretical traditions. Credit will be granted for only one of WMST 100 or GRSJ 101."
+        )
+        self.assertEquals(output, expected_course)
+        

--- a/sleuth_crawler/tests/test_crawler.py
+++ b/sleuth_crawler/tests/test_crawler.py
@@ -37,11 +37,11 @@ class TestBroadCralwer(TestCase):
         req = self.spider.process_req(req_discard)
         self.assertFalse(req)
 
-    @patch('sleuth_crawler.scraper.scraper.spiders.broad_crawler.BroadCrawler.parse_generic_item')
+    @patch('sleuth_crawler.scraper.scraper.spiders.parsers.generic_page_parser.parse_generic_item')
     def test_parse_generic_item(self, fake_parser):
         """
         Test crawler's redirect to generic_page_parser as default parser
         """
-        response = mock_response()
+        response = mock_response(file_name='/test_data/ubc.txt')
         self.spider.parse_generic_item(response)
         self.assertTrue(fake_parser.called)

--- a/sleuth_crawler/tests/test_data/course_details.txt
+++ b/sleuth_crawler/tests/test_data/course_details.txt
@@ -1,0 +1,35 @@
+<h4>GRSJ 101 Introduction to Social Justice</h4>
+<p>
+An overview of intersectional feminist debates and theoretical traditions. Credit will be granted for only one of WMST 100 or GRSJ 101.
+</p>
+
+<table class="table table-bordered mobile-content" ></table>  
+<table class="table table-striped section-summary" >
+<thead><tr>
+<th>Status</th><th>Section</th><th>Activity</th><th>Term</th><th>Interval</th><th>Days</th><th>Start Time</th><th>End Time</th><th>Comments</th>
+</tr></thead>
+<tr class=&#39;section1&#39;><td>Blocked</td>
+<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=5&amp;dept=GRSJ&amp;course=101&amp;section=001" onmouseover="cancelHide=1; popup(); setColor(new Array('t1-4-0','t1-5-0','t1-4-2','t1-5-2','t1-4-4','t1-5-4'),'06739');" onmouseout="cancelHide=0;setTimeout('hideLayer()',2000)">
+GRSJ 101 001
+</a>
+</td>
+
+<td>Lecture</td><td>1</td><td></td>
+<td> Mon Wed Fri</td>
+<td>9:00</td><td>10:00</td>
+<td class="section-comments"><div class='accordion-group accordion-comments'><div class='accordion-heading'><a class='accordion-toggle' data-toggle='collapse'  href='#GRSJ1010010'><img border=0 src="/static/shared/images/go_right.gif" alt='Arrow'>&nbsp; Section Comments </a> </div><div id='GRSJ1010010' class='accordion-body collapse'><div class='accordion-inner'><p>When this course is full it may be blocked to accommodate waitlisted students.</p></div> </div> </div></td>
+</tr><tr class=&#39;section2&#39;><td>Blocked</td>
+<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=5&amp;dept=GRSJ&amp;course=101&amp;section=002" onmouseover="cancelHide=1; popup(); setColor(new Array('t1-5-1','t1-6-1','t1-7-1','t1-5-3','t1-6-3','t1-7-3'),'22371');" onmouseout="cancelHide=0;setTimeout('hideLayer()',2000)">
+GRSJ 101 002
+</a></td>
+
+<td>Lecture</td><td>1</td><td></td>
+<td> Tue Thu</td><td>9:30</td><td>11:00</td>
+<td class="section-comments"><div class='accordion-group accordion-comments'><div class='accordion-heading'><a class='accordion-toggle' data-toggle='collapse'  href='#GRSJ1010020'><img border=0 src="/static/shared/images/go_right.gif" alt='Arrow'>&nbsp; Section Comments </a> </div><div id='GRSJ1010020' class='accordion-body collapse'><div class='accordion-inner'><p>When this course is full it may be blocked to accommodate waitlisted students.</p></div> </div> </div></td>
+</tr><tr class=&#39;section1&#39;><td>&nbsp;</td>
+<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=5&amp;dept=GRSJ&amp;course=101&amp;section=WL2" onmouseover="cancelHide=1; popup(); setColor(new Array('t1-5-1','t1-6-1','t1-5-3','t1-6-3'),'15105');" onmouseout="cancelHide=0;setTimeout('hideLayer()',2000)">
+GRSJ 101 WL2
+</a>  </td>
+
+<td>Waiting List</td><td>1</td><td></td>
+<td> Tue Thu</td><td>9:30</td><td>10:30</td><td class="section-comments"></td>

--- a/sleuth_crawler/tests/test_data/courses.txt
+++ b/sleuth_crawler/tests/test_data/courses.txt
@@ -1,0 +1,18 @@
+<table class="sortable table table-striped" id="mainTable">
+<thead>
+<tr>
+  <th>Course</th><th>Title</th>
+</tr></thead>
+<tbody>
+<tr class=&#39;section1&#39;>
+
+<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=101">GRSJ 101</a></td>
+<td>Introduction to Social Justice</td></tr><tr class=&#39;section2&#39;>
+
+<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=102">GRSJ 102</a></td>
+<td>Global Issues in Social Justice</td></tr><tr class=&#39;section1&#39;>
+
+<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=200">GRSJ 200</a></td>
+<td>Gender and Environmental Justice</td></tr><tr class=&#39;section2&#39;>
+
+</tbody></table>

--- a/sleuth_crawler/tests/test_data/subjects.txt
+++ b/sleuth_crawler/tests/test_data/subjects.txt
@@ -1,0 +1,27 @@
+<table class="sortable table table-striped" id="mainTable" >
+<thead>
+  <tr class=listHeader>
+    <th>Subject Code</th><th>Subject Title</th><th>Faculty / School</th>
+  </tr>
+</thead>
+<tbody>
+<tr class=&#39;section1&#39;>
+<td>
+  <a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=1&amp;dept=AANB">AANB</a>
+</td>
+<td>Applied Animal Biology                             </td>
+<td>Faculty of Land and Food Systems</td></tr><tr class=&#39;section2&#39;>
+
+<td>
+  <a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=1&amp;dept=ACAM">ACAM</a>
+</td>
+<td>Asian Canadian and Asian Migration Studies         </td>
+<td>Faculty of Arts</td></tr><tr class=&#39;section1&#39;>
+
+<td>
+  <a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=1&amp;dept=ADHE">ADHE</a>
+</td>
+<td>Adult and Higher Education                         </td>
+<td>Faculty of Education</td></tr><tr class=&#39;section2&#39;>
+</tbody>
+</table>

--- a/sleuth_crawler/tests/test_data/ubc.txt
+++ b/sleuth_crawler/tests/test_data/ubc.txt
@@ -6,7 +6,7 @@
 <!--[[if (gt IE 9)|(gt IEMobile 7)]><!--><html lang="en"><!--<![endif]-->
 <head>
 <meta charset="utf-8">
-<title>The University of British Columbia</title>
+<title>Homepage | The University of British Columbia</title>
 <meta name="viewport" content="width=device-width">
 <meta name="description" content="The University of British Columbia is a global centre for research and teaching, consistently ranked among the top 20 public universities in the world.">
 <meta property="fb:pages" content="16761458703">

--- a/sleuth_crawler/tests/test_generic_page_parser.py
+++ b/sleuth_crawler/tests/test_generic_page_parser.py
@@ -23,6 +23,8 @@ class TestGenericPageParser(TestCase):
         self.assertTrue(len(item['children']) > 0)
         self.assertEqual(item['description'], "The University of British Columbia is a global centre for research and teaching, consistently ranked among the top 20 public universities in the world.")
         self.assertEqual(item['children'], children)
+        self.assertEqual(item['title'], "Homepage")
+        self.assertEqual(item['site_title'], "The University of British Columbia")
 
         # Check that there are no HTML tags, no blank lines, no JavaScript
         html_regexp = re.compile(r'<[^>]*?>')

--- a/sleuth_crawler/tests/test_generic_page_parser.py
+++ b/sleuth_crawler/tests/test_generic_page_parser.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from sleuth_crawler.tests.mocks import mock_response
+from sleuth_crawler.scraper.scraper.items import ScrapyGenericPage
+from sleuth_crawler.scraper.scraper.spiders.parsers import generic_page_parser as parser
+import re
+
+class TestGenericPageParser(TestCase):
+    """
+    Test GenericPageParser
+    parsers.generic_page_parser
+    """
+
+    def test_parse_generic_item(self):
+        """
+        Test single item parse
+        """
+        response = mock_response('/test_data/ubc.txt', 'http://www.ubc.ca')
+        children = ['http://www.google.com', 'http://www.reddit.com']
+        item = parser.parse_generic_item(response, children)
+        item = ScrapyGenericPage(item)
+        self.assertEqual(item['url'], "http://www.ubc.ca")
+        self.assertTrue(len(item['raw_content']) > 0)
+        self.assertTrue(len(item['children']) > 0)
+        self.assertEqual(item['description'], "The University of British Columbia is a global centre for research and teaching, consistently ranked among the top 20 public universities in the world.")
+        self.assertEqual(item['children'], children)
+
+        # Check that there are no HTML tags, no blank lines, no JavaScript
+        html_regexp = re.compile(r'<[^>]*?>')
+        js_regexp = re.compile(r'{[^*]*?}')
+        for line in item['raw_content']:
+            self.assertTrue(len(line) > 0)
+            self.assertFalse(html_regexp.search(line))
+            self.assertFalse(js_regexp.search(line))

--- a/sleuth_crawler/tests/test_pipelines.py
+++ b/sleuth_crawler/tests/test_pipelines.py
@@ -19,8 +19,8 @@ class TestSolrPipeline(TestCase):
         self.fake_solr.reset_mock()
         item = ScrapyGenericPage(
             url="http://www.ubc.ca",
-            title="",
-            site_title="",
+            title="title",
+            site_title="site title",
             description="",
             raw_content=["description1","description2"],
             children=["www.google.com","www.reddit.com"]
@@ -36,6 +36,8 @@ class TestSolrPipeline(TestCase):
         self.assertTrue(len(doc["children"])==2)
         self.assertTrue(doc["updatedAt"])
         print("Timestamp: " + doc["updatedAt"])
+        self.assertEqual("title", doc["pageName"])
+        self.assertEqual("site title", doc["siteName"])
 
     def test_process_course_item(self):
         """

--- a/sleuth_crawler/tests/test_utils.py
+++ b/sleuth_crawler/tests/test_utils.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+from scrapy.selector import Selector
+import sleuth_crawler.scraper.scraper.spiders.parsers.utils as utils
+import re
+
+class TestUtils(TestCase):
+    """
+    Test parser utils
+    parsers.utils
+    """
+
+    def test_strip_content(self):
+        """
+        Test webpage content stripping
+        """
+        data1 = "<h1>I am a typical HTML bracket</h1>"
+        self.assertEqual(
+            utils.strip_content(data1), ["I am a typical HTML bracket"]
+        )
+        data2 = "<body><p>blabla</p></body><property=''/><script>{def sadfljkasdf}</script>"
+        self.assertEqual(
+            utils.strip_content(data2), ["blabla"]
+        )
+        data_split_lines = "<body> line1 \n line2 \n line3 \n \n line4 </body>"
+        self.assertEqual(
+            utils.strip_content(data_split_lines), ["line1", "line2", "line3", "line4"]
+        )
+        data_invalid = {}
+        self.assertEqual(
+            utils.strip_content(data_invalid), [""]
+        )
+
+    def test_extract_element(self):
+        """
+        Test safe list extraction with default value ""
+        """
+        plist = [
+            Selector(text="el1"),
+            Selector(text="el2"),
+            Selector(text="el3"),
+        ]
+        self.assertTrue(utils.extract_element(plist, 0))
+        self.assertTrue(utils.extract_element(plist, 2))
+        self.assertEqual(utils.extract_element(plist, 5), "")

--- a/sleuth_crawler/tests/test_utils.py
+++ b/sleuth_crawler/tests/test_utils.py
@@ -27,7 +27,7 @@ class TestUtils(TestCase):
         )
         data_invalid = {}
         self.assertEqual(
-            utils.strip_content(data_invalid), [""]
+            utils.strip_content(data_invalid), []
         )
 
     def test_extract_element(self):


### PR DESCRIPTION
## Related Issue
#48, #49
This also grew a little out of scope, oops

## Description
* Unit tests + test data, improved documentation for the new crawler modules added in #45 🥇 
* Updated `generic_page_parser` to get site name and page name if available, both of which are now inserted into Solr
* Removed `pageTitle` from Solr model and tests (the other two `name` fields are enough I think)
* Improved parser robustness with more safe xpath extracts, and other tweaks to parser `utils`
* Added `.coveragerc` which should hopefully exclude coverage of our tests from overall coverage

## WIKI Updates
* Another day, another [Schema](https://github.com/ubclaunchpad/sleuth/wiki/Schemas) update

## Todos

General:
- [x] Tests 🔥 🔥 🔥 
- [x] Documentation
- [x] Wiki
