### PR TITLE
Closes #64, closes #70: New getdocument API, improved search API and queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# nltk
+averaged_perceptron_tagger/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - git clone https://github.com/ubclaunchpad/sleuth-frontend.git ../sleuth-frontend
   - docker-compose up -d solr
   - pip install -r requirements.txt
+  - python scripts/nltk_setup.py
   - bash scripts/wait.sh "Solr" "curl localhost:8983/solr"
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ Getting Started: [Docker](https://docs.docker.com/get-started/),
 
 ## Installation
 
+- Clone this repository and the [Sleuth frontend](https://github.com/ubclaunchpad/sleuth-frontend) into the same directory
 - Install Docker
 - Run
 
 ```Shell
-$ docker-compose up
+$ docker-compose up --build
 ```
 
 - Once containers have started you can `exec` into `bash` in your `web` container and configure a Django admin user.
@@ -43,6 +44,7 @@ root@57d91373cdca:/home/sleuth# python3 manage.py createsuperuser
 
 - The base url for your Django instance should be http://localhost:8000. 
 - To access the Django admin interface make sure you have completed the steps listed above and to go http://localhost:8000/admin.
+- To test the backend API, go to http://localhost:8000/api/[ENDPOINT]/?[PARAMS]
 
 ### Accessing the Sleuth Front-end App
 
@@ -66,7 +68,7 @@ $ bash cd sleuth_crawler/scraper && scrapy crawl broad_crawler
 
 At the moment the crawler never really seems to stop, so you will likely have to force it to quit when you have sufficient data entries.
 
-To empty the a core, go to:
+To empty a core, go to:
 ```
 http://localhost:8983/solr/[CORE_NAME_HERE]/update?stream.body=<delete><query>*:*</query></delete>&commit=true
 ```

--- a/scripts/nltk_setup.py
+++ b/scripts/nltk_setup.py
@@ -1,0 +1,7 @@
+'''
+Download NLTK data
+'''
+
+import nltk
+nltk.download('punkt')
+nltk.download('averaged_perceptron_tagger')

--- a/scripts/start-web.sh
+++ b/scripts/start-web.sh
@@ -5,5 +5,6 @@ echo "Waiting for Solr to boot"
 bash scripts/wait.sh "Solr" "curl -s solr:8983/solr"
 echo "Waiting for Postgres to boot"
 bash scripts/wait.sh "Postgres" "pg_isready -h db -p 5432"
+python scripts/nltk_setup.py
 python manage.py migrate
 python manage.py runserver 0.0.0.0:8000

--- a/sleuth_backend/solr/models.py
+++ b/sleuth_backend/solr/models.py
@@ -52,7 +52,7 @@ class GenericPage(SolrDocument):
         "siteName": "",
         "description": "",
         "content": "",
-        "children": []
+        "links": []
     }
 
     def __init__(self, **kwargs):

--- a/sleuth_backend/solr/query.py
+++ b/sleuth_backend/solr/query.py
@@ -76,7 +76,7 @@ class Query(object):
 
     def fuzz(self, factor):
         '''
-        "Fuzzes" the query by a given factor >0 and <2.
+        "Fuzzes" the query by a given factor where 0 <= factor <=2.
         Acts differently depending on whether the query is a phrase or not.
         For phrases, this factor determines how far about the words of a
         phrase can be found.
@@ -125,13 +125,12 @@ class Query(object):
             'JJ', 'JJR', 'JJS',               # adjective types
             'RB', 'RBR', 'RBS',               # adverbs
         ]
-        words = nltk.word_tokenize(self.query_str)
-        words = nltk.pos_tag(words)
-        print(words)
+        tokens = nltk.word_tokenize(self.query_str)
+        tags = nltk.pos_tag(tokens)
         words_list = []
-        for word in words:
-            if word[1] in tags_to_keep:
-                words_list.append(word[0])
+        for tag in tags:
+            if tag[1] in tags_to_keep:
+                words_list.append(tag[0])
         self.query_str = ' '.join(words_list)
 
     def _escape_special_chars(self):

--- a/sleuth_backend/solr/query.py
+++ b/sleuth_backend/solr/query.py
@@ -68,6 +68,12 @@ class Query(object):
         """
         for term in terms:
             self.query_str += '+{}'.format(term)
+
+    def for_single_field(self, field):
+        '''
+        Apply given field to query
+        '''
+        self.query_str = '{}:{}'.format(field, self.query_str)
     
     def _for_fields(self, fields):
         """

--- a/sleuth_backend/solr/query.py
+++ b/sleuth_backend/solr/query.py
@@ -2,7 +2,7 @@
 Solr query assembling
 '''
 
-#import nltk
+import nltk
 
 class Query(object):
     """
@@ -13,6 +13,7 @@ class Query(object):
         query_str  (str): the desired query
         as_phrase (bool): should this query be formatted as a phrase (default=True)
         escape    (bool): should special characters be escaped from the phrase (default=False)
+        sanitize  (bool): should query be stripped of trivial words (default=False)
 
     Example Usage:
         my_query = Query(query_str)
@@ -21,15 +22,17 @@ class Query(object):
         return str(my_query)                # return query string
     """
 
-    def __init__(self, query_str, as_phrase=True, escape=False):
+    def __init__(self, query_str, as_phrase=True, escape=False, sanitize=False):
         """
         Initialize a query
         """
         self.query_str = query_str
-        self._sanitize()
 
         if escape:
             self._escape_special_chars()
+
+        if sanitize:
+            self._sanitize()
 
         if as_phrase:
             self._as_phrase()
@@ -111,12 +114,25 @@ class Query(object):
         self.query_str = '"{}"'.format(self.query_str)
 
     def _sanitize(self):
-        """
+        '''
         Trim nonessential words such as 'and', 'or', 'for'
-        """
-        # TODO: trim useless words like 'and', 'or', 'for' 
-        # from query if as_phrase is false using NLTK POS tagger
-        self.query_str = ' '.join(self.query_str.split())
+        Parts of Speech types:
+        http://www.ling.upenn.edu/courses/Fall_2003/ling001/penn_treebank_pos.html
+        '''
+        tags_to_keep = [
+            'NN', 'NNS', 'NNP', 'NNPS',       # noun types
+            'VB', 'VBG', 'VBN', 'VBP', 'VBZ', # verb types
+            'JJ', 'JJR', 'JJS',               # adjective types
+            'RB', 'RBR', 'RBS',               # adverbs
+        ]
+        words = nltk.word_tokenize(self.query_str)
+        words = nltk.pos_tag(words)
+        print(words)
+        words_list = []
+        for word in words:
+            if word[1] in tags_to_keep:
+                words_list.append(word[0])
+        self.query_str = ' '.join(words_list)
 
     def _escape_special_chars(self):
         '''

--- a/sleuth_backend/tests/test_models.py
+++ b/sleuth_backend/tests/test_models.py
@@ -16,7 +16,7 @@ class TestModels(TestCase):
                 "siteName": "testsite",
                 "content": "testcontent",
                 "description": "testblurb",
-                "children": []
+                "links": []
             }
             return (args, GenericPage(**args))
         if t == "courseItem":

--- a/sleuth_backend/tests/test_query.py
+++ b/sleuth_backend/tests/test_query.py
@@ -66,3 +66,11 @@ class TestQuery(TestCase):
         terms = ["hack", "wack"]
         query1.select_require(terms)
         self.assertEqual('"hello bruno"+hack+wack', str(query1))
+
+    def test_for_single_field(self):
+        '''
+        Test applying a single field to a query
+        '''
+        query = Query("hello bruno")
+        query.for_single_field('id')
+        self.assertEqual('id:"hello bruno"', str(query))

--- a/sleuth_backend/tests/test_query.py
+++ b/sleuth_backend/tests/test_query.py
@@ -7,35 +7,34 @@ class TestQuery(TestCase):
     Test the Solr query object
     """
 
-    def test_basic_init(self):
+    def test_init(self):
         """
         Test initializing a Query
         as_phrase and not as_phrase
-        with and without proximity parameter
         """
         query_str = "hello"
         query = Query(query_str)
         self.assertEqual('"hello"', str(query))
 
-        query = Query(query_str, proximity=5)
-        self.assertEqual('"hello"~5', str(query))
-
         query = Query(query_str, as_phrase=False)
         self.assertEqual('hello', str(query))
 
-    def test_init_fields(self):
+        query = Query('wow:wow()', escape=True)
+        self.assertEqual('"wow\:wow\(\)"', str(query))
+
+    def test_for_fields(self):
         """
-        Test initializing a Query with fields applied
+        Test applying fields to a Query
         """
-        query_str = "hello bruno"
         fields = {'id':1, 'name':10}
-        query = Query(query_str, fields=fields)
+        query = Query("hello bruno")
+        query.for_fields(fields)
         self.assertEqual(
             '"hello bruno" OR id:("hello bruno")^1 OR name:("hello bruno")^10',
             str(query)
         )
         not_dict = "not clean"
-        self.failUnlessRaises(ValueError, Query, query_str, fields=not_dict)
+        self.failUnlessRaises(ValueError, query.for_fields, not_dict)
 
     def test_boost_importance(self):
         """
@@ -74,3 +73,12 @@ class TestQuery(TestCase):
         query = Query("hello bruno")
         query.for_single_field('id')
         self.assertEqual('id:"hello bruno"', str(query))
+
+    def test_fuzz(self):
+        '''
+        Test applying a fuzz factor to a query
+        '''
+        query = Query("hello bruno")
+        query.fuzz(2)
+        self.assertEqual('"hello bruno"~2', str(query))
+        self.failUnlessRaises(ValueError, query.fuzz, 7)

--- a/sleuth_backend/tests/test_query.py
+++ b/sleuth_backend/tests/test_query.py
@@ -82,3 +82,10 @@ class TestQuery(TestCase):
         query.fuzz(2)
         self.assertEqual('"hello bruno"~2', str(query))
         self.failUnlessRaises(ValueError, query.fuzz, 7)
+
+    def test_sanitation(self):
+        '''
+        Test query init with sanitize=True
+        '''
+        query = Query("The quick brown fox jumped over 12 lazy dogs", sanitize=True)
+        print(str(query))

--- a/sleuth_backend/tests/test_views.py
+++ b/sleuth_backend/tests/test_views.py
@@ -94,15 +94,12 @@ class TestAPI(TestCase):
         mock_response['response']['docs'][0]['name'] = ''
         mock_response['response']['docs'][0]['description'] = 'Nice one dude'
         self.assertEqual(
-            result.content.decode("utf-8"), 
-            str({
-                'data':[mock_response],
-                'request':{
-                    'query':'somequery','types':['genericPage'],
-                    'return_fields':['id','updatedAt','name','description','content'],
-                    'state':''
-                }
-            })
+            json.loads(result.content.decode('utf-8')),
+            {
+                "data": [{"type": "genericPage", "response": {"numFound": 1, "start": 0, "docs": [{"id": "www.cool.com", "description": "Nice one dude", "updatedAt": "", "name": "", "content": ""}]},
+                          "highlighting": {"www.cool.com": {"content": ["Nice one dude"]}}}],
+                "request": {"query": "somequery", "types": ["genericPage"], "return_fields": ["id", "updatedAt", "name", "description", "content"], "state": ""}
+            }
         )
 
         # multicore search
@@ -112,11 +109,11 @@ class TestAPI(TestCase):
         result = search(mock_request)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(
-            result.content.decode("utf-8"), 
-            str({'data': [{'type': 'courseItem', 'response': {'numFound': 1, 'start': 0, 'docs': [{'id': 'www.cool.com', 'description': 'Nice one dude', 'updatedAt': '', 'name': '', 'content': ''}]}, 'highlighting': {'www.cool.com': {'content': ['Nice one dude']}}}, {'type': 'courseItem', 'response': {'numFound': 1, 'start': 0, 'docs': [
-                {'id': 'www.cool.com', 'description': 'Nice one dude', 'updatedAt': '', 'name': '', 'content': ''}]}, 'highlighting': {'www.cool.com': {'content': ['Nice one dude']}}}], 'request': {'query': 'somequery', 'types': ['courseItem', 'courseItem'], 'return_fields': ['id', 'updatedAt', 'name', 'description'], 'state': ''}})
+            json.loads(result.content.decode('utf-8')), 
+            {'data': [{'type': 'courseItem', 'response': {'numFound': 1, 'start': 0, 'docs': [{'id': 'www.cool.com', 'description': 'Nice one dude', 'updatedAt': '', 'name': '', 'content': ''}]}, 'highlighting': {'www.cool.com': {'content': ['Nice one dude']}}}, {'type': 'courseItem', 'response': {'numFound': 1, 'start': 0, 'docs': [
+            {'id': 'www.cool.com', 'description': 'Nice one dude', 'updatedAt': '', 'name': '', 'content': ''}]}, 'highlighting': {'www.cool.com': {'content': ['Nice one dude']}}}], 'request': {'query': 'somequery', 'types': ['courseItem', 'courseItem'], 'return_fields': ['id', 'updatedAt', 'name', 'description'], 'state': ''}}
         )
-
+        
         # getdocument
         params = {
             'id': 'somequery',
@@ -127,9 +124,9 @@ class TestAPI(TestCase):
         result = getdocument(mock_request)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(
-            result.content.decode("utf-8"),
-            str({'data': {'type': 'genericPage', 'doc': {'id': 'www.cool.com', 'description': 'Nice one dude', 'updatedAt': '', 'name': '', 'content': ''}}, 'request': {
-                'query': 'somequery', 'types': ['genericPage'], 'return_fields': ['id', 'updatedAt', 'name', 'description', 'content'], 'state': ''}})
+            json.loads(result.content.decode('utf-8')),
+            {'data': {'type': 'genericPage', 'doc': {'id': 'www.cool.com', 'description': 'Nice one dude', 'updatedAt': '', 'name': '', 'content': ''}}, 'request': {
+            'query': 'somequery', 'types': ['genericPage'], 'return_fields': ['id', 'updatedAt', 'name', 'description', 'content'], 'state': ''}}
         )
 
         mock_query.return_value['response']['numFound'] = 0
@@ -137,10 +134,9 @@ class TestAPI(TestCase):
         result = getdocument(mock_request)
         self.assertEqual(result.status_code, 200)
         self.assertEqual(
-            result.content.decode("utf-8"),
-            str({
-                'data': {'type': '', 'doc': {}}, 'request': {'query': 'somequery', 'types': ['genericPage'], 'return_fields': ['id', 'updatedAt', 'name', 'description', 'content'], 'state': ''}
-            })
+            json.loads(result.content.decode('utf-8')),
+            {'data': {'type': '', 'doc': {}}, 
+            'request': {'query': 'somequery', 'types': ['genericPage'], 'return_fields': ['id', 'updatedAt', 'name', 'description', 'content'], 'state': ''}}
         )
 
     @patch('sleuth_backend.solr.connection.SolrConnection.query')

--- a/sleuth_backend/tests/test_views.py
+++ b/sleuth_backend/tests/test_views.py
@@ -75,7 +75,7 @@ class TestAPI(TestCase):
         }
         params = {
             'q': 'somequery',
-            'core': 'genericPage',
+            'type': 'genericPage',
             'return': 'content'
         }
         mock_request = MockRequest('GET', get=MockGet(params))
@@ -148,7 +148,7 @@ class TestAPI(TestCase):
         }
         params = {
             'q': 'somequery',
-            'core': 'test',
+            'type': 'test',
         }
         expected_response = json.dumps({
             "message": "org.apache.solr.search.SyntaxError on core test",

--- a/sleuth_backend/tests/test_views.py
+++ b/sleuth_backend/tests/test_views.py
@@ -132,12 +132,7 @@ class TestAPI(TestCase):
         mock_query.return_value['response']['numFound'] = 0
         mock_request = MockRequest('GET', get=MockGet(params))
         result = getdocument(mock_request)
-        self.assertEqual(result.status_code, 200)
-        self.assertEqual(
-            json.loads(result.content.decode('utf-8')),
-            {'data': {'type': '', 'doc': {}}, 
-            'request': {'query': 'somequery', 'types': ['genericPage'], 'return_fields': ['id', 'updatedAt', 'name', 'description', 'content'], 'state': ''}}
-        )
+        self.assertEqual(result.status_code, 404)
 
     @patch('sleuth_backend.solr.connection.SolrConnection.query')
     def test_apis_with_error_response(self, mock_query):

--- a/sleuth_backend/urls.py
+++ b/sleuth_backend/urls.py
@@ -1,7 +1,12 @@
+'''
+Lists Sleuth's Django API endpoints
+'''
+
 from django.conf.urls import url
 from .views import views
 
 urlpatterns = [
     url(r'^search/', views.search, name='search'),
     url(r'^cores/', views.cores, name='cores'),
+    url(r'^getdocument/', views.getdocument, name='getdocument'),
 ]

--- a/sleuth_backend/views/error.py
+++ b/sleuth_backend/views/error.py
@@ -41,7 +41,9 @@ class SleuthError(Exception):
         elif error_type is ErrorTypes.SOLR_SEARCH_ERROR:
             self.message = 'Solr returned an error response to the search query.'
         elif error_type is ErrorTypes.INVALID_SEARCH_REQUEST:
-            self.message = 'Must supply a search term with the parameters "q" and "core".'
+            self.message = 'Must supply a search term with the parameter "q".'
+        elif error_type is ErrorTypes.INVALID_GETDOCUMENT_REQUEST:
+            self.message = 'Must supply an ID (url) with the parameter "id".'
         else:
             raise ValueError('Invalid error type. Must be on of ErrorTypes.')
 

--- a/sleuth_backend/views/error.py
+++ b/sleuth_backend/views/error.py
@@ -12,8 +12,10 @@ class ErrorTypes(Enum):
     SOLR_CONNECTION_ERROR = 1
     # Occurs when Solr returns an error response to a search query.
     SOLR_SEARCH_ERROR = 2
-    # Occurs when a search term or core name is missing from a search request.
+    # Occurs when a search term is missing from a search request.
     INVALID_SEARCH_REQUEST = 3
+    # Occurs when a id is missing from a getdocument request
+    INVALID_GETDOCUMENT_REQUEST = 4
 
 class SleuthError(Exception):
     '''

--- a/sleuth_backend/views/views.py
+++ b/sleuth_backend/views/views.py
@@ -4,7 +4,7 @@ Sleuth's Django API handlers
 
 import pysolr
 import json
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from .error import SleuthError, ErrorTypes
 from .views_utils import *
 from sleuth_backend.solr import connection as solr
@@ -128,7 +128,7 @@ def search(request):
             message, status = build_error(e)
             return HttpResponse(message, status=status)
 
-    return HttpResponse(pysolr.force_unicode(responses))
+    return JsonResponse(responses)
 
 def getdocument(request):
     '''
@@ -192,7 +192,7 @@ def getdocument(request):
                     'type': core_to_search,
                     'doc': flatten_doc(query_response['response']['docs'][0], return_fields)
                 }
-                return HttpResponse(pysolr.force_unicode(response))
+                return JsonResponse(response)
 
         # Handle errors and exceptions from each query
         except (Exception, pysolr.SolrError) as e:
@@ -204,4 +204,4 @@ def getdocument(request):
         'type': '',
         'doc': {}
     }
-    return HttpResponse(pysolr.force_unicode(response))
+    return JsonResponse(response)

--- a/sleuth_backend/views/views.py
+++ b/sleuth_backend/views/views.py
@@ -120,8 +120,6 @@ def search(request):
             query_response['type'] = core_to_search
             for doc in query_response['response']['docs']:
                 flatten_doc(doc, return_fields)
-                if 'description' not in doc:
-                    doc['description'] = ''
 
             responses['data'].append(query_response)
 
@@ -165,7 +163,7 @@ def getdocument(request):
 
     kwargs = { 'return_fields': return_fields }
 
-    if id is '':
+    if doc_id is '':
         sleuth_error = SleuthError(ErrorTypes.INVALID_GETDOCUMENT_REQUEST)
         return HttpResponse(sleuth_error.json(), status=400)
 

--- a/sleuth_backend/views/views.py
+++ b/sleuth_backend/views/views.py
@@ -142,7 +142,7 @@ def getdocument(request):
         state: (optional) any string to be returned in response
 
     Example Usage:
-    http:// ... /api/get/?id=https://www.ubc.ca&return=children
+    http:// ... /api/get/?id=https://www.ubc.ca&return=links
 
     Example Response Body:
     {

--- a/sleuth_backend/views/views.py
+++ b/sleuth_backend/views/views.py
@@ -199,9 +199,4 @@ def getdocument(request):
             message, status = build_error(e)
             return HttpResponse(message, status=status)
 
-    # Default return value
-    response['data'] = {
-        'type': '',
-        'doc': {}
-    }
-    return JsonResponse(response)
+    return HttpResponse("Document not found", status=404)

--- a/sleuth_backend/views/views_utils.py
+++ b/sleuth_backend/views/views_utils.py
@@ -40,7 +40,7 @@ def build_search_query(core, query_str, base_kwargs):
     See https://lucene.apache.org/solr/guide/6_6/the-standard-query-parser.html
     for more information about Apache Lucene query syntax.
     '''
-    kwargs = base_kwargs
+    kwargs = base_kwargs.copy()
 
     if core == "genericPage":
         fields = {
@@ -85,7 +85,7 @@ def build_getdocument_query(doc_id, base_kwargs):
     Builds a query and sets parameters to find the document associated with
     the given doc_id
     '''
-    kwargs = base_kwargs
+    kwargs = base_kwargs.copy()
     query = Query(doc_id, as_phrase=False, escape=True)
     query.for_single_field('id')
     # Accomodate extra slash at end of ID query

--- a/sleuth_backend/views/views_utils.py
+++ b/sleuth_backend/views/views_utils.py
@@ -93,6 +93,14 @@ def build_getdocument_query(doc_id, base_kwargs):
     kwargs = base_kwargs
     query = Query(doc_id, as_phrase=False, escape=True)
     query.for_single_field('id')
+    # Accomodate extra slash at end of ID query
+    query_variation = Query(doc_id + '/', as_phrase=False, escape=True)
+    query_variation.for_single_field('id')
+    query.select_or(query_variation)
+    # Accomodate lack of slash at end of ID query
+    query_variation = Query(doc_id.rstrip('/'), as_phrase=False, escape=True)
+    query_variation.for_single_field('id')
+    query.select_or(query_variation)
     kwargs['default_field'] = 'id'
     return (str(query), kwargs)
 

--- a/sleuth_backend/views/views_utils.py
+++ b/sleuth_backend/views/views_utils.py
@@ -51,15 +51,16 @@ def build_search_query(core, query_str, base_kwargs):
     if core == "genericPage":
         fields = {
             'id': 1,
-            'siteName': 8,
             'name': 8,
+            'siteName': 5,
             'description': 5,
-            'content': 2
+            'content': 8
         }
         query = Query(query_str)
         query.fuzz(2)
-        terms_query = Query(query_str, as_phrase=False, escape=True)
-        terms_query.fuzz(2)
+        query.boost_importance(5)
+        terms_query = Query(query_str, as_phrase=False, escape=True, sanitize=True)
+        terms_query.fuzz(1)
         terms_query.for_fields(fields)
         query.select_or(terms_query)
         kwargs['default_field'] = 'content'
@@ -74,7 +75,7 @@ def build_search_query(core, query_str, base_kwargs):
         }
         query = Query(query_str)
         query.fuzz(2)
-        terms_query = Query(query_str, as_phrase=False, escape=True)
+        terms_query = Query(query_str, as_phrase=False, escape=True, sanitize=True)
         terms_query.for_fields(fields)
         query.select_or(terms_query)
         kwargs['default_field'] = 'name'

--- a/sleuth_backend/views/views_utils.py
+++ b/sleuth_backend/views/views_utils.py
@@ -1,0 +1,75 @@
+'''
+Helper methods for Django views
+'''
+
+from sleuth_backend.solr.query import Query
+
+def build_core_request(core, solr_cores):
+    '''
+    Builds a list of cores to search based on given core parameter
+    '''
+    cores_to_search = []
+    if core is '':
+        for c in solr_cores:
+            cores_to_search.append(c)
+    else:
+        cores_to_search.append(core)
+    return cores_to_search
+
+def build_return_fields(fields):
+    '''
+    Builds a string listing the fields to return
+    '''
+    return_fields = 'id,updatedAt,name,description'
+    if fields is not '':
+        return_fields = return_fields + ',' + fields
+    return return_fields
+
+def flatten_doc(doc, return_fields):
+    '''
+    Flattens single-item list fields returned by Solr
+    '''
+    for f in return_fields.split(","):
+        if f in doc:
+            doc[f] = doc[f][0] if len(doc[f]) == 1 else doc[f]
+    return doc
+
+def build_search_query(core, query_str, base_kwargs):
+    '''
+    Builds a search query and sets parameters that is most likely to
+    return the best results for the given core using the given user query.
+    
+    See https://lucene.apache.org/solr/guide/6_6/the-standard-query-parser.html
+    for more information about Apache Lucene query syntax.
+    '''
+    kwargs = base_kwargs
+
+    if core == "genericPage":
+        fields = {
+            'id': 1,
+            'siteName': 10,
+            'name': 10,
+            'description': 5,
+            'content': 2
+        }
+        query = Query(query_str, fields=fields, proximity=5)
+        terms_query = Query(query_str, fields=fields, as_phrase=False)
+        query.select_or(terms_query)
+        kwargs['default_field'] = 'content'
+        kwargs['highlight_fields'] = 'content'
+
+    elif core == "courseItem":
+        fields = {
+            'id': 1,
+            'name': 9,
+            'description': 8,
+            'subjectData': 5,
+        }
+        query = Query(query_str, fields=fields)
+        kwargs['default_field'] = 'name'
+        kwargs['highlight_fields'] = 'description'
+
+    else:
+        query = Query(query_str)
+
+    return (str(query), kwargs)

--- a/sleuth_backend/views/views_utils.py
+++ b/sleuth_backend/views/views_utils.py
@@ -34,6 +34,8 @@ def flatten_doc(doc, return_fields):
     for f in return_fields.split(","):
         if f in doc:
             doc[f] = doc[f][0] if len(doc[f]) == 1 else doc[f]
+        else:
+            doc[f] = ''
     return doc
 
 def build_search_query(core, query_str, base_kwargs):
@@ -49,13 +51,16 @@ def build_search_query(core, query_str, base_kwargs):
     if core == "genericPage":
         fields = {
             'id': 1,
-            'siteName': 10,
-            'name': 10,
+            'siteName': 8,
+            'name': 8,
             'description': 5,
             'content': 2
         }
-        query = Query(query_str, fields=fields, proximity=5)
-        terms_query = Query(query_str, fields=fields, as_phrase=False)
+        query = Query(query_str)
+        query.fuzz(2)
+        terms_query = Query(query_str, as_phrase=False, escape=True)
+        terms_query.fuzz(2)
+        terms_query.for_fields(fields)
         query.select_or(terms_query)
         kwargs['default_field'] = 'content'
         kwargs['highlight_fields'] = 'content'
@@ -67,7 +72,11 @@ def build_search_query(core, query_str, base_kwargs):
             'description': 8,
             'subjectData': 5,
         }
-        query = Query(query_str, fields=fields)
+        query = Query(query_str)
+        query.fuzz(2)
+        terms_query = Query(query_str, as_phrase=False, escape=True)
+        terms_query.for_fields(fields)
+        query.select_or(terms_query)
         kwargs['default_field'] = 'name'
         kwargs['highlight_fields'] = 'description'
 
@@ -82,7 +91,7 @@ def build_getdocument_query(doc_id, base_kwargs):
     the given doc_id
     '''
     kwargs = base_kwargs
-    query = Query(doc_id)
+    query = Query(doc_id, as_phrase=False, escape=True)
     query.for_single_field('id')
     kwargs['default_field'] = 'id'
     return (str(query), kwargs)

--- a/sleuth_backend/views/views_utils.py
+++ b/sleuth_backend/views/views_utils.py
@@ -10,13 +10,7 @@ def build_core_request(core, solr_cores):
     '''
     Builds a list of cores to search based on given core parameter
     '''
-    cores_to_search = []
-    if core is '':
-        for c in solr_cores:
-            cores_to_search.append(c)
-    else:
-        cores_to_search.append(core)
-    return cores_to_search
+    return [c for c in solr_cores] if core is '' else [core]
 
 def build_return_fields(fields):
     '''

--- a/sleuth_crawler/scraper/scraper/items.py
+++ b/sleuth_crawler/scraper/scraper/items.py
@@ -16,7 +16,7 @@ class ScrapyGenericPage(scrapy.Item):
     site_title = scrapy.Field()
     description = scrapy.Field()
     raw_content = scrapy.Field()
-    children = scrapy.Field()
+    links = scrapy.Field()
 
 class ScrapyCourseItem(scrapy.Item):
     """

--- a/sleuth_crawler/scraper/scraper/pipelines.py
+++ b/sleuth_crawler/scraper/scraper/pipelines.py
@@ -48,7 +48,7 @@ class SolrPipeline(object):
             updatedAt=self.__make_date(),
             content=self.__parse_content(item["raw_content"]),
             description=item["description"],
-            children=item["children"]
+            links=item["links"]
         )
         solr_doc.save_to_solr(self.solr_connection)
 

--- a/sleuth_crawler/scraper/scraper/spiders/broad_crawler.py
+++ b/sleuth_crawler/scraper/scraper/spiders/broad_crawler.py
@@ -48,7 +48,8 @@ class BroadCrawler(CrawlSpider):
         """
         Points to generic_page_parser (the default parser for this crawler)
         """
-        children = []
+        links = []
         for link in self.GENERIC_LINK_EXTRACTOR.extract_links(response):
-            children.append(link.url)
-        return generic_page_parser.parse_generic_item(response, children)
+            if link.url != response.url:
+                links.append(link.url)
+        return generic_page_parser.parse_generic_item(response, links)

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
@@ -3,7 +3,7 @@ import re
 from sleuth_crawler.scraper.scraper.spiders.parsers import utils
 from sleuth_crawler.scraper.scraper.items import ScrapyGenericPage
 
-def parse_generic_item(response, children=None):
+def parse_generic_item(response, links):
     """
     Scrape generic page
     """
@@ -25,6 +25,6 @@ def parse_generic_item(response, children=None):
         site_title=site_title,
         description=desc,
         raw_content=raw_content,
-        children=children if children else []
+        links=links
     )
     

--- a/sleuth_crawler/tests/test_crawler.py
+++ b/sleuth_crawler/tests/test_crawler.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from sleuth_crawler.tests.mocks import mock_response
 from sleuth_crawler.scraper.scraper.spiders.broad_crawler import *
 from sleuth_crawler.scraper.scraper.items import *
-import re
 
 class TestBroadCralwer(TestCase):
     """
@@ -45,3 +44,5 @@ class TestBroadCralwer(TestCase):
         response = mock_response(file_name='/test_data/ubc.txt')
         self.spider.parse_generic_item(response)
         self.assertTrue(fake_parser.called)
+        links_arg = fake_parser.call_args[1]
+        self.assertFalse('http://www.ubc.ca' in links_arg)

--- a/sleuth_crawler/tests/test_generic_page_parser.py
+++ b/sleuth_crawler/tests/test_generic_page_parser.py
@@ -15,14 +15,14 @@ class TestGenericPageParser(TestCase):
         Test single item parse
         """
         response = mock_response('/test_data/ubc.txt', 'http://www.ubc.ca')
-        children = ['http://www.google.com', 'http://www.reddit.com']
-        item = parser.parse_generic_item(response, children)
+        links = ['http://www.google.com', 'http://www.reddit.com']
+        item = parser.parse_generic_item(response, links)
         item = ScrapyGenericPage(item)
         self.assertEqual(item['url'], "http://www.ubc.ca")
         self.assertTrue(len(item['raw_content']) > 0)
-        self.assertTrue(len(item['children']) > 0)
+        self.assertTrue(len(item['links']) > 0)
         self.assertEqual(item['description'], "The University of British Columbia is a global centre for research and teaching, consistently ranked among the top 20 public universities in the world.")
-        self.assertEqual(item['children'], children)
+        self.assertEqual(item['links'], links)
         self.assertEqual(item['title'], "Homepage")
         self.assertEqual(item['site_title'], "The University of British Columbia")
 
@@ -39,9 +39,9 @@ class TestGenericPageParser(TestCase):
         Test how site_title is assembled from site Title element
         """
         response = mock_response('<title>Homepage - Subtitle 1 - Subtitle 2 - The University of British Columbia</title>')
-        item = ScrapyGenericPage(parser.parse_generic_item(response))
+        item = ScrapyGenericPage(parser.parse_generic_item(response, []))
         self.assertEqual(item['site_title'], "Subtitle 2 - The University of British Columbia")
 
         response = mock_response('<title>Engineering alumna gives back as a WiSE Mentor | Women in Science and Engineering</title>')
-        item = ScrapyGenericPage(parser.parse_generic_item(response))
+        item = ScrapyGenericPage(parser.parse_generic_item(response, []))
         self.assertEqual(item['site_title'], "Women in Science and Engineering")

--- a/sleuth_crawler/tests/test_pipelines.py
+++ b/sleuth_crawler/tests/test_pipelines.py
@@ -23,7 +23,7 @@ class TestSolrPipeline(TestCase):
             site_title="site title",
             description="",
             raw_content=["description1","description2"],
-            children=["www.google.com","www.reddit.com"]
+            links=["www.google.com","www.reddit.com"]
         )
         self.pipeline.process_item(item)
 
@@ -33,7 +33,7 @@ class TestSolrPipeline(TestCase):
         self.assertEqual("genericPage", doc_type)
         self.assertEqual("http://www.ubc.ca", doc["id"])
         self.assertEqual("description1 description2", doc["content"])
-        self.assertTrue(len(doc["children"])==2)
+        self.assertTrue(len(doc["links"])==2)
         self.assertTrue(doc["updatedAt"])
         print("Timestamp: " + doc["updatedAt"])
         self.assertEqual("title", doc["name"])
@@ -56,7 +56,6 @@ class TestSolrPipeline(TestCase):
         doc = args[1]
         self.assertEqual("courseItem", doc_type)
         self.assertEqual("subject.url", doc["id"])
-        #TODO
 
     def test_close_spider(self):
         """


### PR DESCRIPTION
## Related Issues
Closes #64 - get document by ID
Closes #70 - API response format is wrong
Makes progress on #54 - improve search relevance

## Description
#### API Changes
* 🥑 New API endpoint (`/api/getdocument/`) for getting individual document by ID (url)
* 🚧 Fixed bad API response format - now returns `JsonResponse`
* 📡 APIs now take `type` instead of `core` as parameter, and `core` field is returned as `type`
* 🔗 `children` field has been renamed to `links`, and `links` should no longer contain references to self (_**delete `genericItem` core and run the crawler again for changes to take effect**_)
* 🇨🇦 API responses now return all requested fields even if found documents do not have said field (values default to empty string)

#### Other Changes
* 📁 [NLTK](http://www.nltk.org) setup - scripts to download datasets, etc
* ✨ Several new `Query` features, including `sanitize` using NLTK and `fuzz`
* 🔎 Updated query building for each core to improve relevance
* 🚰 Cleaned up some unit tests
* 🔨 Moved some repeated functionality from `views.py` into `views_utils.py`
* 📖 Small update to setup instructions in README and fixed a minor typo

## WIKI Updates
* [Backend API](https://github.com/ubclaunchpad/sleuth/wiki/Backend-API)

## Todos

General:
- [x] Tests
- [x] Documentation
- [x] Wiki