### PR TITLE
Closes #79: Update Query object to be declarative, fix sanitation

### DIFF
--- a/sleuth_backend/solr/connection.py
+++ b/sleuth_backend/solr/connection.py
@@ -31,10 +31,13 @@ class SolrConnection(object):
 
     def core_names(self):
         """
-        Returns a list of know cores in the Solr instance without making a
-        request to Solr.
+        Returns a list of known valid cores in the Solr instance without
+        making a request to Solr - this request excludes cores used for testing.
         """
-        return list(self.cores.keys())
+        valid_cores = list(self.cores.keys())
+        if 'test' in valid_cores:
+            valid_cores.remove('test')
+        return valid_cores
 
     def fetch_core_schema(self, name):
         """

--- a/sleuth_backend/solr/query.py
+++ b/sleuth_backend/solr/query.py
@@ -5,7 +5,7 @@ Solr query assembling
 import nltk
 
 class Query(object):
-    """
+    '''
     This object allows component-based building and manipulation of Solr query strings.
     See class for available query manipulations.
 
@@ -16,16 +16,25 @@ class Query(object):
         sanitize  (bool): should query be stripped of trivial words (default=False)
 
     Example Usage:
-        my_query = Query(query_str)
-        my_query.select_and(other_query)    # my_query AND other_query
-        my_query.select_or(other_query)     # my_query OR other_query
-        return str(my_query)                # return query string
-    """
+        query = Query(doc_id, as_phrase=False, escape=True) \
+            .for_single_field('id') \
+            .select_or(
+                Query(doc_id + '/', as_phrase=False, escape=True) \
+                .for_single_field('id') \
+                .select_or(query_variation)
+            )
+        
+        query = Query(doc_id, as_phrase=False, escape=True).for_single_field('id')
+        query_variation = Query(doc_id + '/', as_phrase=False, escape=True) \
+            .for_single_field('id') \
+            .select_or(query_variation)
+        combination = query.select_or(query_variation)
+    '''
 
     def __init__(self, query_str, as_phrase=True, escape=False, sanitize=False):
-        """
-        Initialize a query
-        """
+        '''
+        Initialize a query with given parameters
+        '''
         self.query_str = query_str
 
         if escape:
@@ -38,41 +47,67 @@ class Query(object):
             self._as_phrase()
 
     def __str__(self):
-        """
+        '''
         Return query as a string
-        """
+        '''
         return self.query_str
 
     def boost_importance(self, factor):
-        """
-        Raise the immportance of this query to given factor
-        """
-        self.query_str = '({})^{}'.format(self.query_str, str(factor))
+        '''
+        Return new query that raises the immportance of this
+        query to given factor
+        '''
+        return Query(
+            '({})^{}'.format(self.query_str, str(factor)),
+            as_phrase=False
+        )
 
     def select_and(self, query):
-        """
-        Join this query and another query with an AND select
-        """
-        self.query_str = '{} AND {}'.format(self.query_str, str(query))
+        '''
+        Return new query that joins this query and another query
+        with an AND select
+        '''
+        return Query(
+            '{} AND {}'.format(self.query_str, str(query)),
+            as_phrase=False
+        )
 
     def select_or(self, query):
-        """
-        Join this query and another query with an OR select
-        """
-        self.query_str = '{} OR {}'.format(self.query_str, str(query))
+        '''
+        Return new query that joins this query and another query
+        with an OR select
+        '''
+        return Query(
+            '{} OR {}'.format(self.query_str, str(query)),
+            as_phrase=False
+        )
 
     def select_require(self, terms):
-        """
+        '''
         Make query require the given terms
-        """
+        '''
+        if len(terms) == 0:
+            return self
+
+        new_query_str = self.query_str
         for term in terms:
-            self.query_str += '+{}'.format(term)
+            new_query_str += '+{}'.format(term)
+        return Query(
+            new_query_str,
+            as_phrase=False
+        )
 
     def for_single_field(self, field):
         '''
         Apply given field to query
         '''
-        self.query_str = '{}:{}'.format(field, self.query_str)
+        if field == "":
+            return self
+
+        return Query(
+            '{}:{}'.format(field, self.query_str),
+            as_phrase=False
+        )
 
     def fuzz(self, factor):
         '''
@@ -85,32 +120,45 @@ class Query(object):
         '''
         if factor < 0 or factor > 2:
             raise ValueError('Factor must be between 0 and 2.')
-        self.query_str = '{}~{}'.format(self.query_str, factor)
+
+        return Query(
+            '{}~{}'.format(self.query_str, factor),
+            as_phrase=False
+        )
 
     def for_fields(self, fields):
-        """
+        '''
         Apply given fields to query
-        """
+        '''
         if type(fields) is not dict:
             raise ValueError('Fields must be a dict of field names and boost factors')
-        self._for_fields_helper(self.query_str, list(fields.items()))
+
+        return Query(
+            self.query_str,
+            as_phrase=False
+        ).select_or(self._for_fields_helper(self.query_str, list(fields.items())))
 
     def _for_fields_helper(self, query_str, fields):
-        if not fields:
-            return
-    
         field, boost = fields[0]
-        query = Query(query_str, as_phrase=False)
-        query.boost_importance(boost)
-        query = Query('{}:{}'.format(field, str(query)), as_phrase=False)
-        self.select_or(query)
-        self._for_fields_helper(query_str, fields[1:])
+        query = Query(query_str, as_phrase=False).boost_importance(boost)
+        query = Query(
+            '{}:{}'.format(field, str(query)),
+            as_phrase=False
+        )
+        if fields[1:]:
+            return query.select_or(query._for_fields_helper(query_str, fields[1:]))
+        else:
+            return query
+
+    ##################
+    # INIT MODIFIERS #
+    ##################
 
     def _as_phrase(self):
-        """
+        '''
         Format query as entire phrase, and optionally set proximity for
         words within the phrase.
-        """
+        '''
         self.query_str = '"{}"'.format(self.query_str)
 
     def _sanitize(self):
@@ -131,7 +179,8 @@ class Query(object):
         for tag in tags:
             if tag[1] in tags_to_keep:
                 words_list.append(tag[0])
-        self.query_str = ' '.join(words_list)
+        new_query_str = ' '.join(words_list)
+        self.query_str = new_query_str if len(new_query_str)>0 else self.query_str
 
     def _escape_special_chars(self):
         '''

--- a/sleuth_backend/tests/test_query.py
+++ b/sleuth_backend/tests/test_query.py
@@ -27,8 +27,7 @@ class TestQuery(TestCase):
         Test applying fields to a Query
         """
         fields = {'id':1, 'name':10}
-        query = Query("hello bruno")
-        query.for_fields(fields)
+        query = Query("hello bruno").for_fields(fields)
         self.assertEqual(
             '"hello bruno" OR id:("hello bruno")^1 OR name:("hello bruno")^10',
             str(query)
@@ -41,8 +40,7 @@ class TestQuery(TestCase):
         Test boosting the importance of a query
         """
         query_str = "hello bruno"
-        query = Query(query_str)
-        query.boost_importance(5)
+        query = Query(query_str).boost_importance(5)
         self.assertEqual('("hello bruno")^5', str(query))
 
     def test_selects(self):
@@ -52,34 +50,35 @@ class TestQuery(TestCase):
         # AND
         query1 = Query("hello bruno")
         query2 = Query("bye bruno")
-        query1.select_and(query2)
-        self.assertEqual('"hello bruno" AND "bye bruno"', str(query1))
+        combined_query = query1.select_and(query2)
+        self.assertEqual('"hello bruno" AND "bye bruno"', str(combined_query))
 
         # OR
         query1 = Query("hello bruno")
-        query1.select_or(query2)
-        self.assertEqual('"hello bruno" OR "bye bruno"', str(query1))
+        combined_query = query1.select_or(query2)
+        self.assertEqual('"hello bruno" OR "bye bruno"', str(combined_query))
 
         # REQUIRE
-        query1 = Query("hello bruno")
         terms = ["hack", "wack"]
-        query1.select_require(terms)
-        self.assertEqual('"hello bruno"+hack+wack', str(query1))
+        query = Query("hello bruno").select_require(terms)
+        self.assertEqual('"hello bruno"+hack+wack', str(query))
+        query = Query("hello bruno").select_require([])
+        self.assertEqual('"hello bruno"', str(query))
 
     def test_for_single_field(self):
         '''
         Test applying a single field to a query
         '''
-        query = Query("hello bruno")
-        query.for_single_field('id')
+        query = Query("hello bruno").for_single_field('id')
         self.assertEqual('id:"hello bruno"', str(query))
+        query = Query("hello bruno").for_single_field('')
+        self.assertEqual('"hello bruno"', str(query))
 
     def test_fuzz(self):
         '''
         Test applying a fuzz factor to a query
         '''
-        query = Query("hello bruno")
-        query.fuzz(2)
+        query = Query("hello bruno").fuzz(2)
         self.assertEqual('"hello bruno"~2', str(query))
         self.failUnlessRaises(ValueError, query.fuzz, 7)
 
@@ -89,3 +88,7 @@ class TestQuery(TestCase):
         '''
         query = Query("The quick brown fox jumped over 12 lazy dogs", sanitize=True)
         print(str(query))
+
+        # If query only contains garbage, should use original string
+        query = Query('and and but but', sanitize=True)
+        self.assertEqual('"and and but but"', str(query))


### PR DESCRIPTION
## Related Issue
Closes #79 
Fixes #80 

## Description
* 🚧 Rewrite Query in declarative format, so chaining can now be done:
```py
query = Query(doc_id, as_phrase=False, escape=True) \
    .for_single_field('id') \
    .select_or(
        Query(doc_id + '/', as_phrase=False, escape=True) \
        .for_single_field('id') \
        .select_or(query_variation)
    )
```
* 🚫 Fix bug with `sanitize` that would cause Solr to do bad things, also added some checks against possible similar situations
* ✨ Updated tests, `views_utils`, documentation to reflect changes
* 🔨 (303a583) `test` core no longer gets returned in `connection.core_names()` to prevent it from being searched during a multicore search

## WIKI Updates
* none

## Todos

General:
- [x] Tests
- [x] Documentation
- [ ] Wiki