### PR TITLE
Solr insertion queues, crawler prioritization, improved genericPage parsing

### DIFF
--- a/sleuth_backend/solr/connection.py
+++ b/sleuth_backend/solr/connection.py
@@ -9,7 +9,7 @@ class SolrConnection(object):
 
     # The number of documents held in a core's insert queue before
     # the documents in the core are automatically inserted.
-    QUEUE_THRESHOLD = 50
+    QUEUE_THRESHOLD = 100
 
     def __init__(self, url):
         '''

--- a/sleuth_backend/solr/connection.py
+++ b/sleuth_backend/solr/connection.py
@@ -57,7 +57,7 @@ class SolrConnection(object):
 
         return response['schema']
 
-    def insert_document(self, core, doc):
+    def queue_document(self, core, doc):
         '''
         Queues a document for insertion into the specified core and returns None.
         If the number of documents in the queue exceeds a certain threshold,

--- a/sleuth_backend/solr/connection.py
+++ b/sleuth_backend/solr/connection.py
@@ -3,46 +3,52 @@ import json
 import requests
 
 class SolrConnection(object):
-    """
+    '''
     Connection to Solr database
-    """
+    '''
+
+    # The number of documents held in a core's insert queue before
+    # the documents in the core are automatically inserted.
+    QUEUE_THRESHOLD = 50
 
     def __init__(self, url):
-        """
+        '''
         Creates a SolrConnection form the given base Solr url of the form
         'http://<solrhostname>:<port>/solr'.
-        """
+        '''
         self.url = url
         self.solr = pysolr.Solr(url, timeout=10)
         self.solr_admin = pysolr.SolrCoreAdmin(url + '/admin/cores')
         self.cores = {}
+        self.queues = {}
 
         for core_name in self.fetch_core_names():
             self.cores[core_name] = pysolr.Solr(self.url + '/' + core_name)
+            self.queues[core_name] = list()
 
     def fetch_core_names(self):
-        """
+        '''
         Makes a request to Solr and returns an array of strings where each
         string is the name of a core in the response from Solr.
-        """
+        '''
         status_response = self.solr_admin.status()
         status = json.loads(status_response)
         return [core_name for core_name in status['status']]
 
     def core_names(self):
-        """
+        '''
         Returns a list of known valid cores in the Solr instance without
         making a request to Solr - this request excludes cores used for testing.
-        """
+        '''
         valid_cores = list(self.cores.keys())
         if 'test' in valid_cores:
             valid_cores.remove('test')
         return valid_cores
 
     def fetch_core_schema(self, name):
-        """
+        '''
         Returns the schema of the core with the given name as a dictionary.
-        """
+        '''
         response = self._get_url("{}/{}/schema".format(self.url, name), {})
 
         if 'schema' not in response:
@@ -52,18 +58,49 @@ class SolrConnection(object):
         return response['schema']
 
     def insert_document(self, core, doc):
-        """
-        Attempts to insert the given document (a dict) into the solr core with
-        the given name and returns the response from Solr. All values in 'doc'
-        must be strings.
-        """
+        '''
+        Queues a document for insertion into the specified core and returns None.
+        If the number of documents in the queue exceeds a certain threshold,
+        this function will insert them all the documents held in the queue of the
+        specified core and return the response from Solr.
+        All values in 'doc' must be strings.
+        '''
         if core not in self.cores:
             raise ValueError("A core for the document type {} was not found".format(core))
-        return self.cores[core].add([doc])
+
+        self.queues[core].append(doc)
+
+        if len(self.queues[core]) >= self.QUEUE_THRESHOLD:
+            docs = list(self.queues[core].copy())
+            del self.queues[core][:]
+            return self.insert_documents(core, docs)
+
+        return None
+
+    def insert_documents(self, core_name, docs):
+        '''
+        Inserts given list of documents into specified core. Returns Solr response.
+        '''
+        if core_name not in self.cores:
+            raise ValueError('No Solr core with the name "{}" was found'.format(core_name))
+        print('Inserting '+str(len(docs))+' items into core '+core_name)
+        return self.cores[core_name].add(docs)
+
+    def insert_queued(self):
+        '''
+        Inserts all queued documents across all cores. Returns an object
+        containing the Solr response from each core.
+        '''
+        response = {}
+        for core in self.cores:
+            docs = list(self.queues[core].copy())
+            del self.queues[core][:]
+            response[core] = self.insert_documents(core, docs)
+        return response
 
     def query(self, core, query, sort="", start="", rows="", default_field="",
         search_fields="", return_fields="", highlight_fields="", omit_header=True):
-        """
+        '''
         Returns the response body from Solr corresponding to the given query.
         See https://lucene.apache.org/solr/guide/6_6/common-query-parameters.html
         and https://lucene.apache.org/solr/guide/6_6/highlighting.html
@@ -87,7 +124,7 @@ class SolrConnection(object):
             highlight_fields (str): Specifies a list of fields to highlight.
             omit_header (bool): Whether or not Solr should include a header with
                         metadata about the query in its response.
-        """
+        '''
         params = {
             "q": query,
             "wt": "json",
@@ -112,23 +149,22 @@ class SolrConnection(object):
         return self._get_url("{}/{}/select".format(self.url, core), params)
 
     def optimize(self, core_name=None):
-        """
-        Performs defragmentation of all/specified core(s) in Solr database
-        Optionally accepts ``core_name``. Default is ``None`
-        """
+        '''
+        Performs defragmentation of specified core in Solr database.
+        If no core is specified, defragments all cores.
+        '''
         if core_name:
-            try:
-                self.cores[core_name].optimize()
-            except KeyError as e:
-                raise KeyError('No Solr core with the name "{}" was found'.format(core_name))
+            if core_name not in self.cores:
+                raise ValueError('No Solr core with the name "{}" was found'.format(core_name))
+            self.cores[core_name].optimize()
         else:
             for core in self.cores:
                 self.cores[core].optimize()
 
     def _get_url(self, url, params):
-        """
+        '''
         Makes a request to the given url relative to the base url with the given
         parameters and returns the response as a JSON string.
-        """
+        '''
         response = requests.get(url, params=pysolr.safe_urlencode(params))
         return response.json()

--- a/sleuth_backend/solr/models.py
+++ b/sleuth_backend/solr/models.py
@@ -31,7 +31,7 @@ class SolrDocument(object):
         Submits the document to the given Solr connection. This method should not
         be overridden.
         """
-        solr_connection.insert_document(self.type(), self.doc)
+        solr_connection.insert_document(self.type(), self.doc.copy())
 
     def type(self):
         """

--- a/sleuth_backend/solr/models.py
+++ b/sleuth_backend/solr/models.py
@@ -3,10 +3,10 @@ import time
 from . import connection as solr
 
 class SolrDocument(object):
-    """
+    '''
     An base class for documents that are inserted into Solr, an retured as 
     search results from the Sleuth API.
-    """
+    '''
 
     # Default doc fields: all subtypes must at least have these fields
     doc = {
@@ -18,32 +18,32 @@ class SolrDocument(object):
     }
 
     def __init__(self, doc, **kwargs):
-        """
+        '''
         This method should be called by the subclass constructor.
-        """
+        '''
         self.doc = doc
         for key in self.doc.keys():
-            if key in kwargs and key is not "type":
+            if key in kwargs and key is not 'type':
                 doc[key] = kwargs[key]
 
     def save_to_solr(self, solr_connection):
-        """
+        '''
         Submits the document to the given Solr connection. This method should not
         be overridden.
-        """
-        solr_connection.insert_document(self.type(), self.doc.copy())
+        '''
+        solr_connection.queue_document(self.type(), self.doc.copy())
 
     def type(self):
-        """
+        '''
         Returns a string representing the document type. This method should not
         be overridden.
-        """
-        return self.doc["type"]
+        '''
+        return self.doc['type']
 
 class GenericPage(SolrDocument):
-    """
+    '''
     Represents a generic web page.
-    """
+    '''
     doc = {
         "id": "",
         "type": "genericPage",
@@ -59,9 +59,9 @@ class GenericPage(SolrDocument):
         super(GenericPage, self).__init__(self.doc, **kwargs)
 
 class CourseItem(SolrDocument):
-    """
+    '''
     Represents a UBC course.
-    """
+    '''
     doc = {
         "id": "",
         "type": "courseItem",

--- a/sleuth_backend/tests/test_models.py
+++ b/sleuth_backend/tests/test_models.py
@@ -3,9 +3,10 @@ from sleuth_backend.solr.models import SolrDocument, GenericPage, CourseItem
 from unittest.mock import MagicMock
 
 class TestModels(TestCase):
-    """
+    '''
     Test Solr document types
-    """
+    '''
+    
     def create_page(self, t):
         if t == "genericPage":
             args = {
@@ -43,6 +44,6 @@ class TestModels(TestCase):
     def test_save_to_solr(self):
         args, page = self.create_page("genericPage")
         mock = MagicMock()
-        mock.insert_document.return_value = None
+        mock.queue_document.return_value = None
         page.save_to_solr(mock)
-        mock.insert_document.assert_called_with("genericPage", args)
+        mock.queue_document.assert_called_with("genericPage", args)

--- a/sleuth_backend/tests/test_query.py
+++ b/sleuth_backend/tests/test_query.py
@@ -33,7 +33,8 @@ class TestQuery(TestCase):
             str(query)
         )
         not_dict = "not clean"
-        self.failUnlessRaises(ValueError, query.for_fields, not_dict)
+        with self.assertRaises(ValueError):
+            query.for_fields(not_dict)
 
     def test_boost_importance(self):
         """
@@ -80,7 +81,8 @@ class TestQuery(TestCase):
         '''
         query = Query("hello bruno").fuzz(2)
         self.assertEqual('"hello bruno"~2', str(query))
-        self.failUnlessRaises(ValueError, query.fuzz, 7)
+        with self.assertRaises(ValueError):
+            query.fuzz(7)
 
     def test_sanitation(self):
         '''

--- a/sleuth_crawler/scraper/scraper/pipelines.py
+++ b/sleuth_crawler/scraper/scraper/pipelines.py
@@ -17,10 +17,12 @@ class SolrPipeline(object):
         self.solr_connection = solr_connection
 
     def close_spider(self, spider=None):
-        """
+        '''
         Defragment Solr database after spider completes task
-        """
-        print("Scraper: Optimizing cores and closing spider")
+        '''
+        print("Closing scraper: Emptying all queued documents")
+        self.solr_connection.insert_queued()
+        print("Closing scraper: Optimizing all cores")
         self.solr_connection.optimize()
 
     def process_item(self, item, spider=None):

--- a/sleuth_crawler/scraper/scraper/settings.py
+++ b/sleuth_crawler/scraper/scraper/settings.py
@@ -33,6 +33,9 @@ PARENT_URLS = [
 
 ### Custom Settings:
 
+# Process lower depth requests first
+DEPTH_PRIORITY = 50
+
 # Obey robots.txt rules
 ROBOTSTXT_OBEY = True
 

--- a/sleuth_crawler/scraper/scraper/settings.py
+++ b/sleuth_crawler/scraper/scraper/settings.py
@@ -24,7 +24,8 @@ NEWSPIDER_MODULE = 'scraper.spiders'
 # Place specific domains before www.ubc.ca
 PARENT_URLS = [
     'https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=0',
-    'http://www.ubc.ca',
+    'https://www.ubyssey.ca',
+    'https://www.ubc.ca',
 ]
 
 # Crawl responsibly by identifying yourself (and your website) on the user-agent

--- a/sleuth_crawler/scraper/scraper/spiders/broad_crawler.py
+++ b/sleuth_crawler/scraper/scraper/spiders/broad_crawler.py
@@ -11,8 +11,8 @@ class BroadCrawler(CrawlSpider):
     name = "broad_crawler"
 
     GENERIC_LINK_EXTRACTOR = LinkExtractor(
-        allow=(r'ubc', r'universityofbc', ),
-        deny=(r'accounts\.google', r'intent', )
+        allow=(r'ubc', r'universityofbc', r'ubyssey'),
+        deny=(r'accounts\.google', r'intent', r'lang=')
     )
 
     start_urls = PARENT_URLS
@@ -41,7 +41,7 @@ class BroadCrawler(CrawlSpider):
                 return req.replace(callback=course_parser.parse_subjects)
             else:
                 return
-        
+
         return req
         
     def parse_generic_item(self, response):

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/course_parser.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/course_parser.py
@@ -1,22 +1,26 @@
 import scrapy
+import re
 from sleuth_crawler.scraper.scraper.spiders.parsers import utils
 from sleuth_crawler.scraper.scraper.items import ScrapyCourseItem
 
 BASE_URL = "https://courses.students.ubc.ca"
+SESSION_PATTERN = re.compile(r';jsessionid=[^?]*', re.IGNORECASE)
 
 def parse_subjects(response):
-    """
+    '''
     Scrape for Courses.
     Iterates through Subjects in this page.
     Passes to parse_course, parse_course_details
-    """
+    '''
     rows = response.xpath('//tbody/tr')
     for row in rows:
         next_rel_url = utils.extract_element(row.xpath('./td/a/@href'), 0)
         if len(next_rel_url) > 1:
             next_url = BASE_URL + next_rel_url
+            next_url = re.sub(SESSION_PATTERN, '', next_url)
             title = utils.extract_element(row.xpath('./td[2]/text()'), 0)
             code = utils.extract_element(row.xpath('./td/a/text()'), 0)
+
             subject = {
                 "url": next_url,
                 "name": code+" "+title.strip(),
@@ -31,10 +35,10 @@ def parse_subjects(response):
             )
 
 def parse_course(response):
-    """
+    '''
     Parse subjct page.
     Iterates through the Courses on this page.
-    """
+    '''
     subject = response.meta['data']
     rows = response.xpath('//tbody/tr')
     for row in rows:
@@ -42,13 +46,17 @@ def parse_course(response):
         course_code = utils.extract_element(row.xpath('./td/a/text()'), 0)
         course_title = utils.extract_element(row.xpath('./td[2]/text()'), 0)
         course_name = course_code+" "+course_title
+        
         if len(next_rel_url) > 1:
             next_url = BASE_URL + next_rel_url
+            next_url = re.sub(SESSION_PATTERN, '', next_url)
+
             course = ScrapyCourseItem(
                 subject=subject,
                 url=next_url,
                 name=course_name,
             )
+
             yield scrapy.Request(
                 next_url,
                 callback=parse_course_details,
@@ -57,9 +65,9 @@ def parse_course(response):
             )
 
 def parse_course_details(response):
-    """
+    '''
     Parse course details page.
-    """
+    '''
     course = response.meta['data']
     course['description'] = utils.extract_element(response.xpath('//p/text()'), 0).strip()
     # TODO: List of sections into course[sections], maybe parse as well

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/course_parser.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/course_parser.py
@@ -26,6 +26,7 @@ def parse_subjects(response):
             yield scrapy.Request(
                 next_url,
                 callback=parse_course,
+                priority=100,
                 meta={'data':subject}
             )
 
@@ -51,6 +52,7 @@ def parse_course(response):
             yield scrapy.Request(
                 next_url,
                 callback=parse_course_details,
+                priority=100,
                 meta={'data':course}
             )
 

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/generic_page_parser.py
@@ -4,19 +4,40 @@ from sleuth_crawler.scraper.scraper.spiders.parsers import utils
 from sleuth_crawler.scraper.scraper.items import ScrapyGenericPage
 
 def parse_generic_item(response, links):
-    """
+    '''
     Scrape generic page
-    """
-    site_title = ""
-    title = utils.extract_element(response.xpath("//title/text()"), 0)
+    '''
+    title = utils.extract_element(response.xpath("//title/text()"), 0).strip()
     titles = re.split(r'\| | - ', title)
-    if len(titles) >= 2:
+
+    # Use OpenGraph title data if available
+    if len(response.xpath('//meta[@property="og:site_name"]')) > 0 and \
+        len(response.xpath('//meta[@property="og:title"]')) > 0:
+        title = utils.extract_element(
+            response.xpath('//meta[@property="og:title"]/@content'), 0
+        )
+        site_title = utils.extract_element(
+            response.xpath('//meta[@property="og:site_name"]/@content'), 0
+        )
+    elif len(titles) >= 2:
         title = titles[0].strip()
         site_titles = []
         for i in range(max(1, len(titles)-2), len(titles)):
             site_titles.append(titles[i].strip())
-        site_title = " - ".join(site_titles)
-    desc = utils.extract_element(response.xpath("//meta[@name='description']/@content"), 0)
+        site_title = ' - '.join(site_titles)
+    else:
+        site_title = ''
+
+    # Use OpenGraph description if available
+    if len(response.xpath('//meta[@property="og:description"]')) > 0:
+        desc = utils.extract_element(
+            response.xpath('//meta[@property="og:description"]/@content'), 0
+        )
+    else:
+        desc = utils.extract_element(
+            response.xpath('//meta[@name="description"]/@content'), 0
+        )
+
     raw_content = utils.strip_content(response.body)
 
     return ScrapyGenericPage(

--- a/sleuth_crawler/scraper/scraper/spiders/parsers/utils.py
+++ b/sleuth_crawler/scraper/scraper/spiders/parsers/utils.py
@@ -10,11 +10,12 @@ def strip_content(data):
         for script in soup(["script", "style"]):
             script.decompose()
         data = soup.get_text()
-        # strip extraneous line breaks and sort into list
+        # strip extraneous line breaks, discard very short lines,
+        # return the remaining lines as a list
         lines = []
         for line in data.splitlines():
             line = line.strip()
-            if line:
+            if line and len(line) > 5:
                 lines.append(line)
         return lines
     except Exception:

--- a/sleuth_crawler/tests/test_course_parser.py
+++ b/sleuth_crawler/tests/test_course_parser.py
@@ -55,8 +55,9 @@ class TestCourseParser(TestCase):
                 name="GRSJ 102 Global Issues in Social Justice"
             )
         ]
+        #print(expected_courses[0]['url'].replace(';jsessionid=[^?]*', ''))
         self.assertEquals(output[0].callback.__name__, parser.parse_course_details.__name__)
-        self.assertEquals(output[0].meta['data'],expected_courses[0])
+        self.assertEquals(output[0].meta['data']['url'],expected_courses[0]['url'])
         self.assertEquals(output[0].priority, 100)
         self.assertEquals(output[1].meta['data'],expected_courses[1])
 
@@ -72,4 +73,3 @@ class TestCourseParser(TestCase):
             description="An overview of intersectional feminist debates and theoretical traditions. Credit will be granted for only one of WMST 100 or GRSJ 101."
         )
         self.assertEquals(output, expected_course)
-        

--- a/sleuth_crawler/tests/test_course_parser.py
+++ b/sleuth_crawler/tests/test_course_parser.py
@@ -5,15 +5,15 @@ from sleuth_crawler.scraper.scraper.spiders.parsers import course_parser as pars
 import re
 
 class TestCourseParser(TestCase):
-    """
+    '''
     Test GenericCourseParser
     parsers.course_oarser
-    """
+    '''
 
     def test_parse_subjects(self):
-        """
+        '''
         Test subjects parsing
-        """
+        '''
         response = mock_response('/test_data/subjects.txt', 'https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=0')
         output = list(parser.parse_subjects(response))
         expected_subjects = [
@@ -30,12 +30,13 @@ class TestCourseParser(TestCase):
         ]
         self.assertEquals(output[0].callback.__name__, parser.parse_course.__name__)
         self.assertEquals(output[0].meta['data'],expected_subjects[0])
+        self.assertEquals(output[0].priority, 100)
         self.assertEquals(output[1].meta['data'],expected_subjects[1])
 
     def test_parse_course(self):
-        """
+        '''
         Test courses parsing
-        """
+        '''
         response = mock_response(
             '/test_data/courses.txt', 
             'https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=1&dept=ASTR'
@@ -56,12 +57,13 @@ class TestCourseParser(TestCase):
         ]
         self.assertEquals(output[0].callback.__name__, parser.parse_course_details.__name__)
         self.assertEquals(output[0].meta['data'],expected_courses[0])
+        self.assertEquals(output[0].priority, 100)
         self.assertEquals(output[1].meta['data'],expected_courses[1])
 
     def test_parse_course_details(self):
-        """
+        '''
         Test course details parsing
-        """
+        '''
         response = mock_response('/test_data/course_details.txt', 'https://courses.students.ubc.ca/cs/main?pname=subjarea&tname=subjareas&req=3&dept=ASTR&course=200')
         response.meta['data'] = ScrapyCourseItem(subject="",url="",name="")
         output = parser.parse_course_details(response)

--- a/sleuth_crawler/tests/test_data/courses.txt
+++ b/sleuth_crawler/tests/test_data/courses.txt
@@ -6,13 +6,13 @@
 <tbody>
 <tr class=&#39;section1&#39;>
 
-<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=101">GRSJ 101</a></td>
+<td><a href="/cs/main;jsessionid=w5wKylv2Jz5DIbdOakm816jO?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=101">GRSJ 101</a></td>
 <td>Introduction to Social Justice</td></tr><tr class=&#39;section2&#39;>
 
-<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=102">GRSJ 102</a></td>
+<td><a href="/cs/main;jsessionid=w5wKylv2Jz5DIbdOakm816jO?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=102">GRSJ 102</a></td>
 <td>Global Issues in Social Justice</td></tr><tr class=&#39;section1&#39;>
 
-<td><a href="/cs/main?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=200">GRSJ 200</a></td>
+<td><a href="/cs/main;jsessionid=w5wKylv2Jz5DIbdOakm816jO?pname=subjarea&amp;tname=subjareas&amp;req=3&amp;dept=GRSJ&amp;course=200">GRSJ 200</a></td>
 <td>Gender and Environmental Justice</td></tr><tr class=&#39;section2&#39;>
 
 </tbody></table>

--- a/sleuth_crawler/tests/test_data/metadata.txt
+++ b/sleuth_crawler/tests/test_data/metadata.txt
@@ -1,0 +1,11 @@
+<title>The Ubyssey - UBC's official student newspaper</title>
+<link rel="canonical" href="https://www.ubyssey.ca/">
+<meta name="description" content="Weekly student newspaper of the University of British Columbia." />
+
+<!-- Open Graph data -->
+<meta property="og:title" content="OG The Ubyssey - UBC's official student newspaper" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://www.ubyssey.ca/" />
+<meta property="og:image" content="https://ubyssey.storage.googleapis.com/static/images/ubyssey-logo-square.png" />
+<meta property="og:description" content="OG Weekly student newspaper of the University of British Columbia." />
+<meta property="og:site_name" content="OG The Ubyssey" />

--- a/sleuth_crawler/tests/test_generic_page_parser.py
+++ b/sleuth_crawler/tests/test_generic_page_parser.py
@@ -45,3 +45,13 @@ class TestGenericPageParser(TestCase):
         response = mock_response('<title>Engineering alumna gives back as a WiSE Mentor | Women in Science and Engineering</title>')
         item = ScrapyGenericPage(parser.parse_generic_item(response, []))
         self.assertEqual(item['site_title'], "Women in Science and Engineering")
+
+    def test_opengraph_metadata_use(self):
+        '''
+        Test how OpenGraph metadata is used
+        '''
+        response = mock_response('/test_data/metadata.txt', 'https://www.ubyssey.ca/')
+        item = ScrapyGenericPage(parser.parse_generic_item(response, []))
+        self.assertEqual(item['title'], "OG The Ubyssey - UBC's official student newspaper")
+        self.assertEqual(item['site_title'], 'OG The Ubyssey')
+        self.assertEqual(item['description'], 'OG Weekly student newspaper of the University of British Columbia.')

--- a/sleuth_crawler/tests/test_pipelines.py
+++ b/sleuth_crawler/tests/test_pipelines.py
@@ -3,19 +3,20 @@ from unittest.mock import MagicMock, patch
 from sleuth_crawler.scraper.scraper.pipelines import *
 
 class TestSolrPipeline(TestCase):
-    """
+    '''
     Test Solr Pipeline
     ubc_homepage_spider.py
-    """
+    '''
+    
     @patch('sleuth_backend.solr.connection.SolrConnection')
     def setUp(self, fake_solr):
         self.fake_solr = fake_solr
         self.pipeline = SolrPipeline(fake_solr)
 
     def test_process_generic_page(self):
-        """
+        '''
         Test Generic Page processing
-        """
+        '''
         self.fake_solr.reset_mock()
         item = ScrapyGenericPage(
             url="http://www.ubc.ca",
@@ -40,9 +41,9 @@ class TestSolrPipeline(TestCase):
         self.assertEqual("site title", doc["siteName"])
 
     def test_process_course_item(self):
-        """
+        '''
         Test Course Item processing
-        """
+        '''
         self.fake_solr.reset_mock()
         item = ScrapyCourseItem(
             subject={"url":"some.url","name":"somename","faculty":"somefaculty"},
@@ -58,14 +59,14 @@ class TestSolrPipeline(TestCase):
         self.assertEqual("subject.url", doc["id"])
 
     def test_close_spider(self):
-        """
+        '''
         Test that closing spider calls solrConnection.optimize()
-        """
+        '''
         self.pipeline.close_spider()
         self.assertTrue(self.fake_solr.optimize.called)
 
     def __assert_and_return_args(self):
-        args = self.fake_solr.insert_document.call_args[0]
+        args = self.fake_solr.queue_document.call_args[0]
         self.assertTrue(args[0])
         self.assertTrue(args[1])
         doc_type = args[0]

--- a/sleuth_crawler/tests/test_utils.py
+++ b/sleuth_crawler/tests/test_utils.py
@@ -21,9 +21,9 @@ class TestUtils(TestCase):
         self.assertEqual(
             utils.strip_content(data2), ["blabla"]
         )
-        data_split_lines = "<body> line1 \n line2 \n line3 \n \n line4 </body>"
+        data_split_lines = "<body> line12345 \n line22345 \n line32345 \n \n line42345 </body>"
         self.assertEqual(
-            utils.strip_content(data_split_lines), ["line1", "line2", "line3", "line4"]
+            utils.strip_content(data_split_lines), ["line12345", "line22345", "line32345", "line42345"]
         )
         data_invalid = {}
         self.assertEqual(


### PR DESCRIPTION
## Related Issues
branch name is a lie
Closes #82 : Queue solr document insertion
Closes #73 : Crawler prioritization
Closes #72 : Improve genericPage content parsing

## Description
* 🔗 Queues items when calling ~~`connection.insert_document()`~~ `connection.queue_document()` up to a certain threshold before bulk inserting. Can force insertion using `insert_documents()` and `insert_queued()` - for example, the crawler calls the latter when closing the pipeline.
* 💯 Assign higher priority for requests to parse `courseItem` children
* 📈 Parse OpenGraph metadata if available for `genericPage`
* 🗑 Discard short lines when assembling raw page content for `genericPage`

* 🦄 (6083423) Remove `jsessionid` from Course URLs to prevent duplicates

* 🔨 (204412b) Rename `insert_document` to `queue_document` to reflect functionality, slight rewrite of `test_connection`

## WIKI Updates
* none

## Todos

General:
- [x] Tests
- [ ] Documentation
- [ ] Wiki