### PR TITLE
Fixes #89: Fix crawler callback reassignment, improve run_crawlers script

### DIFF
--- a/sleuth_crawler/run_crawlers.sh
+++ b/sleuth_crawler/run_crawlers.sh
@@ -1,6 +1,33 @@
 #!/bin/bash
-# Runs all crawlers
+# Utility script for running crawlers
+
+usage="
+  Usage: `basename $0` [-h] [-t n]
+
+  where:
+    -h    show help text
+    -t    set how long to run spiders for (in seconds)
+"
+
+while getopts ':ht:' option; do
+  case "$option" in
+    h) echo "$usage"
+       exit
+       ;;
+    t) time=$OPTARG
+       ;;
+    :) printf "  Missing argument for -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+   \?) printf "  Illegal option: -%s\n" "$OPTARG" >&2
+       echo "$usage" >&2
+       exit 1
+       ;;
+  esac
+done
 
 echo 'Spinning up crawlers...'
 cd sleuth_crawler/scraper
-python crawl.py & read -t 10 ; kill $!
+python crawl.py & read -t $time ; kill $!
+echo 'Crawler run for ' $time ' seconds'

--- a/sleuth_crawler/scraper/scraper/spiders/broad_crawler.py
+++ b/sleuth_crawler/scraper/scraper/spiders/broad_crawler.py
@@ -40,11 +40,9 @@ class BroadCrawler(CrawlSpider):
         if 'reddit.com' in req.url:
             req = req.replace(priority=100)
             if 'comments' in req.url:
-                req = req.replace(callback='parse_reddit_post')
+                req = req.replace(callback=self.parse_reddit_post)
             else:
-                req = req.replace(callback='no_parse')
-        else:
-            req = req.replace(callback='parse_generic_item')
+                req = req.replace(callback=self.no_parse)
 
         return req
 

--- a/sleuth_crawler/tests/test_crawler.py
+++ b/sleuth_crawler/tests/test_crawler.py
@@ -32,15 +32,17 @@ class TestBroadCralwer(TestCase):
         '''
         req_in = scrapy.Request(url='https://www.reddit.com')
         req = self.spider.process_request(req_in)
-        self.assertEqual(req.callback, 'no_parse')
+        self.assertEqual(req.callback.__name__, 'no_parse')
 
         req_in = scrapy.Request(url='https://www.reddit.com/r/ubc/comments/123')
         req = self.spider.process_request(req_in)
-        self.assertEqual(req.callback, 'parse_reddit_post')
+        self.assertEqual(req.callback.__name__, 'parse_reddit_post')
 
+        # process_request should not try to reassign callback on
+        # a normal website for generic_page_parser
         req_in = scrapy.Request(url='https://www.bruno.com')
         req = self.spider.process_request(req_in)
-        self.assertEqual(req.callback, 'parse_generic_item')
+        self.assertEqual(req.callback, None)
 
     @patch('sleuth_crawler.scraper.scraper.spiders.parsers.generic_page_parser.parse_generic_item')
     def test_parse_generic_item(self, fake_parser):


### PR DESCRIPTION
## Related Issue
#89 crawler fails

## Description
* ⚠️  Fixed `callback` reassignment in Crawler (specifically `process_request`) that was causing the `broad_crawler` to fail, oops

* 🔧 Improved `run_crawlers` script - can now specify how long to run the spiders for, and also added documentation. Example to run for 10 minutes:
```bash
bash sleuth_crawler/run_crawlers.sh -t 600
```

## WIKI Updates
* none

## Todos

General:
- [x] Tests
- [x] Documentation
- [ ] Wiki