### PR TITLE
API type and return fields checking, request multiple cores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ venv.bak/
 
 # nltk
 averaged_perceptron_tagger/
+
+*.DS_Store

--- a/sleuth_backend/solr/models.py
+++ b/sleuth_backend/solr/models.py
@@ -93,3 +93,14 @@ class RedditPost(SolrDocument):
 
     def __init__(self, **kwargs):
         super(RedditPost, self).__init__(self.doc, **kwargs)
+
+models = [SolrDocument, GenericPage, CourseItem, RedditPost]
+
+def get_models_fields():
+    '''
+    Return a list of the doc description of each model type
+    '''
+    fields = []
+    for d in [m.doc for m in models]:
+        fields += [k for k, _ in d.items() if k not in fields]
+    return fields

--- a/sleuth_backend/solr/models.py
+++ b/sleuth_backend/solr/models.py
@@ -94,13 +94,13 @@ class RedditPost(SolrDocument):
     def __init__(self, **kwargs):
         super(RedditPost, self).__init__(self.doc, **kwargs)
 
-models = [SolrDocument, GenericPage, CourseItem, RedditPost]
+MODELS = [GenericPage, CourseItem, RedditPost]
 
 def get_models_fields():
     '''
     Return a list of the doc description of each model type
     '''
     fields = []
-    for d in [m.doc for m in models]:
+    for d in [m.doc for m in MODELS]:
         fields += [k for k, _ in d.items() if k not in fields]
     return fields

--- a/sleuth_backend/tests/test_models.py
+++ b/sleuth_backend/tests/test_models.py
@@ -1,5 +1,5 @@
 from django.test import TestCase
-from sleuth_backend.solr.models import SolrDocument, GenericPage, CourseItem
+from sleuth_backend.solr.models import SolrDocument, GenericPage, CourseItem, get_models_fields
 from unittest.mock import MagicMock
 
 class TestModels(TestCase):
@@ -48,3 +48,10 @@ class TestModels(TestCase):
         mock.queue_document.return_value = None
         page.save_to_solr(mock)
         mock.queue_document.assert_called_with("genericPage", args)
+
+    def test_get_models_fields(self):
+        result = get_models_fields()
+        self.assertEquals(
+            ['id', 'type', 'name', 'updatedAt', 'description', 'siteName', 'content', 'links', 'subjectId', 'subjectName', 'faculty', 'comments', 'subreddit'],
+            result
+        )

--- a/sleuth_backend/tests/test_models.py
+++ b/sleuth_backend/tests/test_models.py
@@ -52,6 +52,6 @@ class TestModels(TestCase):
     def test_get_models_fields(self):
         result = get_models_fields()
         self.assertEquals(
-            ['id', 'type', 'name', 'updatedAt', 'description', 'siteName', 'content', 'links', 'subjectId', 'subjectName', 'faculty', 'comments', 'subreddit'],
+            ['id', 'type', 'name', 'updatedAt', 'siteName', 'description', 'content', 'links', 'subjectId', 'subjectName', 'faculty', 'comments', 'subreddit'],
             result
         )

--- a/sleuth_backend/tests/test_views.py
+++ b/sleuth_backend/tests/test_views.py
@@ -61,6 +61,8 @@ class TestAPI(TestCase):
     @patch('sleuth_backend.solr.connection.SolrConnection.core_names')
     @patch('sleuth_backend.solr.connection.SolrConnection.query')
     def test_apis_with_valid_request(self, mock_query, mock_cores):
+        mock_cores.return_value = ['genericPage', 'redditPost', 'courseItem']
+
         # genericPage search
         mock_query.return_value = {
             "type": "genericPage",
@@ -93,6 +95,7 @@ class TestAPI(TestCase):
         mock_response['response']['docs'][0]['updatedAt'] = ''
         mock_response['response']['docs'][0]['name'] = ''
         mock_response['response']['docs'][0]['description'] = 'Nice one dude'
+        self.maxDiff = None
         self.assertEqual(
             json.loads(result.content.decode('utf-8')),
             {
@@ -124,6 +127,7 @@ class TestAPI(TestCase):
         mock_response = mock_query.return_value
         
         # getdocument
+        mock_cores.return_value = ['genericPage', 'redditPost', 'courseItem']        
         params = {
             'id': 'somequery',
             'type': 'genericPage',
@@ -143,8 +147,11 @@ class TestAPI(TestCase):
         result = getdocument(mock_request)
         self.assertEqual(result.status_code, 404)
 
+    @patch('sleuth_backend.solr.connection.SolrConnection.core_names')
     @patch('sleuth_backend.solr.connection.SolrConnection.query')
-    def test_apis_with_error_response(self, mock_query):
+    def test_apis_with_error_response(self, mock_query, mock_cores):
+        mock_cores.return_value = ['test']        
+
         # Solr response error
         mock_query.return_value = {
             "error": {

--- a/sleuth_backend/tests/test_views.py
+++ b/sleuth_backend/tests/test_views.py
@@ -118,6 +118,7 @@ class TestAPI(TestCase):
         )
 
         # redditPost search
+        mock_cores.return_value = ['genericPage', 'redditPost', 'courseItem']
         mock_query.return_value['type'] = 'redditPost'
         mock_query.return_value['highlighting']['www.cool.com'] = {'content': ['Nice']}
         params = { 'q': 'somequery', 'type': 'redditPost' }
@@ -126,8 +127,7 @@ class TestAPI(TestCase):
         self.assertEqual(result.status_code, 200)
         mock_response = mock_query.return_value
         
-        # getdocument
-        mock_cores.return_value = ['genericPage', 'redditPost', 'courseItem']        
+        # getdocument       
         params = {
             'id': 'somequery',
             'type': 'genericPage',
@@ -202,3 +202,15 @@ class TestAPI(TestCase):
         mock_request = MockRequest('GET', get=MockGet({'id':'query'}))
         result = getdocument(mock_request)
         self.assertEqual(result.status_code, 500)
+
+        # Invalid param error
+        params = {
+            'q': 'somequery',
+            'type': 'asdlialisfas',
+        }
+        mock_request = MockRequest('GET', get=MockGet(params))
+        result = search(mock_request)
+        self.assertEqual(result.status_code, 400)
+        mock_request = MockRequest('GET', get=MockGet({'id':'query','type':'asdf'}))
+        result = getdocument(mock_request)
+        self.assertEqual(result.status_code, 400)

--- a/sleuth_backend/tests/test_views_utils.py
+++ b/sleuth_backend/tests/test_views_utils.py
@@ -2,39 +2,45 @@ import sleuth_backend.views.views_utils as utils
 from django.test import TestCase
 
 class TestViewsUtils(TestCase):
+    '''
+    Test views utility functions
+    '''
 
     def test_build_core_request(self):
+        '''
+        Test building list of requested cores
+        '''
         solr_cores = ['genericPage', 'redditPost', 'courseItem']
 
         # one requested core
         result = utils.build_core_request('genericPage', solr_cores)
-        self.assertEquals(['genericPage'], result)        
+        self.assertEquals(['genericPage'], result)
 
         # multiple requested cores
         result = utils.build_core_request('genericPage,redditPost', solr_cores)
         self.assertEquals(['genericPage', 'redditPost'], result)
 
         # some invalid cores
-        result = utils.build_core_request('wow,redditPost', solr_cores)
-        self.assertEquals(['redditPost'], result)
+        with self.assertRaises(ValueError):
+            utils.build_core_request('wow,redditPost', solr_cores)
 
         # all cores invalid
-        result = utils.build_core_request('geasdficPage,redasdf', solr_cores)
-        self.assertEquals(solr_cores, result)
+        with self.assertRaises(ValueError):
+            utils.build_core_request('geasdficPage,redasdf', solr_cores)
 
         # no given cores
         result = utils.build_core_request('', solr_cores)
         self.assertEquals(solr_cores, result)
 
     def test_build_return_fields(self):
+        '''
+        Test building string of return fields
+        '''
         result = utils.build_return_fields('')
         self.assertEquals('id,updatedAt,name,description', result)
 
-        result = utils.build_return_fields('asdfasdf')
-        self.assertEquals('id,updatedAt,name,description', result)
+        with self.assertRaises(ValueError):
+            utils.build_return_fields('asdfasdf')
 
-        result = utils.build_return_fields('links,sadf')
-        self.assertEquals('id,updatedAt,name,description,links', result)
-
-        result = utils.build_return_fields('asdf,links,subreddit')
-        self.assertEquals('id,updatedAt,name,description,links,subreddit', result)
+        with self.assertRaises(ValueError):
+            utils.build_return_fields('links,sadf')

--- a/sleuth_backend/tests/test_views_utils.py
+++ b/sleuth_backend/tests/test_views_utils.py
@@ -1,0 +1,40 @@
+import sleuth_backend.views.views_utils as utils
+from django.test import TestCase
+
+class TestViewsUtils(TestCase):
+
+    def test_build_core_request(self):
+        solr_cores = ['genericPage', 'redditPost', 'courseItem']
+
+        # one requested core
+        result = utils.build_core_request('genericPage', solr_cores)
+        self.assertEquals(['genericPage'], result)        
+
+        # multiple requested cores
+        result = utils.build_core_request('genericPage,redditPost', solr_cores)
+        self.assertEquals(['genericPage', 'redditPost'], result)
+
+        # some invalid cores
+        result = utils.build_core_request('wow,redditPost', solr_cores)
+        self.assertEquals(['redditPost'], result)
+
+        # all cores invalid
+        result = utils.build_core_request('geasdficPage,redasdf', solr_cores)
+        self.assertEquals(solr_cores, result)
+
+        # no given cores
+        result = utils.build_core_request('', solr_cores)
+        self.assertEquals(solr_cores, result)
+
+    def test_build_return_fields(self):
+        result = utils.build_return_fields('')
+        self.assertEquals('id,updatedAt,name,description', result)
+
+        result = utils.build_return_fields('asdfasdf')
+        self.assertEquals('id,updatedAt,name,description', result)
+
+        result = utils.build_return_fields('links,sadf')
+        self.assertEquals('id,updatedAt,name,description,links', result)
+
+        result = utils.build_return_fields('asdf,links,subreddit')
+        self.assertEquals('id,updatedAt,name,description,links,subreddit', result)

--- a/sleuth_backend/views/error.py
+++ b/sleuth_backend/views/error.py
@@ -12,9 +12,9 @@ class ErrorTypes(Enum):
     SOLR_CONNECTION_ERROR = 1
     # Occurs when Solr returns an error response to a search query.
     SOLR_SEARCH_ERROR = 2
-    # Occurs when a search term is missing from a search request.
+    # Occurs when a search term is missing/incorrect in a search request.
     INVALID_SEARCH_REQUEST = 3
-    # Occurs when a id is missing from a getdocument request
+    # Occurs when something is missing/incorrect in a getdocument request.
     INVALID_GETDOCUMENT_REQUEST = 4
 
 class SleuthError(Exception):

--- a/sleuth_backend/views/views.py
+++ b/sleuth_backend/views/views.py
@@ -80,10 +80,15 @@ def search(request):
     if request.method != 'GET':
         return HttpResponse(status=405)
 
-    cores_to_search = utils.build_core_request(request.GET.get('type', ''), SOLR.core_names())
+    try:
+        cores_to_search = utils.build_core_request(request.GET.get('type', ''), SOLR.core_names())
+        return_fields = utils.build_return_fields(request.GET.get('return', ''))
+    except ValueError as err:
+        sleuth_error = SleuthError(ErrorTypes.INVALID_SEARCH_REQUEST, str(err))
+        return HttpResponse(sleuth_error.json(), status=400)
+
     query = request.GET.get('q', '')
     state = request.GET.get('state', '')
-    return_fields = utils.build_return_fields(request.GET.get('return', ''))
 
     kwargs = {
         'sort': request.GET.get('sort', ''),
@@ -156,10 +161,15 @@ def getdocument(request):
     if request.method != 'GET':
         return HttpResponse(status=405)
 
-    cores_to_search = utils.build_core_request(request.GET.get('type', ''), SOLR.core_names())
+    try:
+        cores_to_search = utils.build_core_request(request.GET.get('type', ''), SOLR.core_names())
+        return_fields = utils.build_return_fields(request.GET.get('return', ''))
+    except ValueError as err:
+        sleuth_error = SleuthError(ErrorTypes.INVALID_SEARCH_REQUEST, str(err))
+        return HttpResponse(sleuth_error.json(), status=400)
+
     doc_id = request.GET.get('id', '')
     state = request.GET.get('state', '')
-    return_fields = utils.build_return_fields(request.GET.get('return', ''))
 
     kwargs = { 'return_fields': return_fields }
 

--- a/sleuth_backend/views/views.py
+++ b/sleuth_backend/views/views.py
@@ -5,8 +5,8 @@ Sleuth's Django API handlers
 import pysolr
 import json
 from django.http import HttpResponse, JsonResponse
+import sleuth_backend.views.views_utils as utils
 from .error import SleuthError, ErrorTypes
-from .views_utils import *
 from sleuth_backend.solr import connection as solr
 from sleuth.settings import HAYSTACK_CONNECTIONS
 
@@ -80,10 +80,10 @@ def search(request):
     if request.method != 'GET':
         return HttpResponse(status=405)
 
-    cores_to_search = build_core_request(request.GET.get('type', ''), SOLR.core_names())
+    cores_to_search = utils.build_core_request(request.GET.get('type', ''), SOLR.core_names())
     query = request.GET.get('q', '')
     state = request.GET.get('state', '')
-    return_fields = build_return_fields(request.GET.get('return', ''))
+    return_fields = utils.build_return_fields(request.GET.get('return', ''))
 
     kwargs = {
         'sort': request.GET.get('sort', ''),
@@ -107,7 +107,7 @@ def search(request):
     }
     for core_to_search in cores_to_search:
         try:
-            new_query, new_kwargs = build_search_query(core_to_search, query, kwargs)
+            new_query, new_kwargs = utils.build_search_query(core_to_search, query, kwargs)
             query_response = SOLR.query(core_to_search, new_query, **new_kwargs)
             if 'error' in query_response:
                 sleuth_error = SleuthError(
@@ -119,13 +119,13 @@ def search(request):
             # Attach type to response and flatten single-item list fields
             query_response['type'] = core_to_search
             for doc in query_response['response']['docs']:
-                flatten_doc(doc, return_fields)
+                utils.flatten_doc(doc, return_fields)
 
             responses['data'].append(query_response)
 
         # Handle errors and exceptions from each query
         except (Exception, pysolr.SolrError) as e:
-            message, status = build_error(e)
+            message, status = utils.build_error(e)
             return HttpResponse(message, status=status)
 
     return JsonResponse(responses)
@@ -156,10 +156,10 @@ def getdocument(request):
     if request.method != 'GET':
         return HttpResponse(status=405)
 
-    cores_to_search = build_core_request(request.GET.get('type', ''), SOLR.core_names())
+    cores_to_search = utils.build_core_request(request.GET.get('type', ''), SOLR.core_names())
     doc_id = request.GET.get('id', '')
     state = request.GET.get('state', '')
-    return_fields = build_return_fields(request.GET.get('return', ''))
+    return_fields = utils.build_return_fields(request.GET.get('return', ''))
 
     kwargs = { 'return_fields': return_fields }
 
@@ -178,7 +178,7 @@ def getdocument(request):
     }
     for core_to_search in cores_to_search:
         try:
-            new_query, new_kwargs = build_getdocument_query(doc_id, kwargs)
+            new_query, new_kwargs = utils.build_getdocument_query(doc_id, kwargs)
             query_response = SOLR.query(core_to_search, new_query, **new_kwargs)
             if 'error' in query_response:
                 sleuth_error = SleuthError(
@@ -190,13 +190,13 @@ def getdocument(request):
                 # Return result if a value is found
                 response['data'] = {
                     'type': core_to_search,
-                    'doc': flatten_doc(query_response['response']['docs'][0], return_fields)
+                    'doc': utils.flatten_doc(query_response['response']['docs'][0], return_fields)
                 }
                 return JsonResponse(response)
 
         # Handle errors and exceptions from each query
         except (Exception, pysolr.SolrError) as e:
-            message, status = build_error(e)
+            message, status = utils.build_error(e)
             return HttpResponse(message, status=status)
 
     return HttpResponse("Document not found", status=404)

--- a/sleuth_backend/views/views_utils.py
+++ b/sleuth_backend/views/views_utils.py
@@ -10,25 +10,36 @@ import sleuth_backend.solr.models as models
 def build_core_request(core, solr_cores):
     '''
     Builds a list of cores to search based on given core parameter
-    Also checks requested cores against available cores and discards
-    invalid requested cores
+    Also checks requested cores against available cores and raises
+    an exception if core is invalid
     '''
+    if core is '':
+        return solr_cores
+
     core_params = [s for s in core.split(',')]
-    core_params = [c for c in core_params if c in solr_cores]
-    return solr_cores if len(core_params) is 0 else core_params
+    bad_core_params = [c for c in core_params if c not in solr_cores]
+    if len(bad_core_params) > 0:
+        raise ValueError('Invalid type(s) requested: ' + ','.join(bad_core_params))
+
+    return core_params
 
 def build_return_fields(fields):
     '''
     Builds a string listing the fields to return
     Also checks requested return fields against available return fields
-    and discards invalid return fields
+    and raises an exception if cores is invalid
     '''
     return_fields = 'id,updatedAt,name,description'
+    if fields is '':
+        return return_fields
+
     fields_list = [s for s in fields.split(',')]
-    fields_list = [f for f in fields_list if f in models.get_models_fields()]
-    if len(fields_list) > 0:
-        return_fields = return_fields + ',' + ",".join(fields_list)
-    return return_fields
+    valid_fields = models.get_models_fields()
+    bad_fields = [f for f in fields_list if f not in valid_fields]
+    if len(bad_fields) > 0:
+        raise ValueError('Invalid return return field(s) requested: ' + ','.join(bad_fields))
+
+    return return_fields + ',' + ','.join(fields_list)
 
 def flatten_doc(doc, return_fields):
     '''

--- a/sleuth_backend/views/views_utils.py
+++ b/sleuth_backend/views/views_utils.py
@@ -5,20 +5,29 @@ Helper methods for Django views
 from pysolr import SolrError
 from .error import SleuthError, ErrorTypes
 from sleuth_backend.solr.query import Query
+import sleuth_backend.solr.models as models
 
 def build_core_request(core, solr_cores):
     '''
     Builds a list of cores to search based on given core parameter
+    Also checks requested cores against available cores and discards
+    invalid requested cores
     '''
-    return [c for c in solr_cores] if core is '' else [core]
+    core_params = [s for s in core.split(',')]
+    core_params = [c for c in core_params if c in solr_cores]
+    return solr_cores if len(core_params) is 0 else core_params
 
 def build_return_fields(fields):
     '''
     Builds a string listing the fields to return
+    Also checks requested return fields against available return fields
+    and discards invalid return fields
     '''
     return_fields = 'id,updatedAt,name,description'
-    if fields is not '':
-        return_fields = return_fields + ',' + fields
+    fields_list = [s for s in fields.split(',')]
+    fields_list = [f for f in fields_list if f in models.get_models_fields()]
+    if len(fields_list) > 0:
+        return_fields = return_fields + ',' + ",".join(fields_list)
     return return_fields
 
 def flatten_doc(doc, return_fields):


### PR DESCRIPTION
## Related Issue
#83 - allow multiple cores
#86 - check requested params

## Description
* 🍼 Request multiple cores for all endpoints (e.g. `type=genericPage,courseItem`)

* ☑️ Check validity of `type` and `return_fields`, otherwise return `INVALIDSEARCHREQUEST`

## WIKI Updates
* [backend api](https://github.com/ubclaunchpad/sleuth/wiki/Backend-API)

## Todos

General:
- [x] Tests
- [x] Documentation
- [x] Wiki